### PR TITLE
fix: add workspace and user skill paths to skills-behavior config

### DIFF
--- a/behaviors/skills.yaml
+++ b/behaviors/skills.yaml
@@ -14,6 +14,8 @@ tools:
     config:
       skills:
         - "git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=skills"
+        - ".amplifier/skills"
+        - "~/.amplifier/skills"
       visibility:
         enabled: true
         inject_role: "user"


### PR DESCRIPTION
## Summary

Add `.amplifier/skills` (workspace) and `~/.amplifier/skills` (user) to the `config.skills` list in `skills-behavior`. These paths stack with remote curated sources via `deep_merge` list concatenation, ensuring workspace skills are discoverable alongside curated remote skills.

## Problem

When `skills-behavior` sets `config.skills` to a remote git URL, `_resolve_skill_sources()` only sees those explicit sources. The `get_default_skills_dirs()` fallback — which includes `.amplifier/skills` and `~/.amplifier/skills` — is only called when `config.skills` is empty. Since three behaviors in a default foundation session always populate `config.skills`, the fallback never triggers and workspace skills are invisible.

## Fix

Add the default paths directly to `skills-behavior`'s `config.skills` list. Multiple behaviors' skill lists concatenate via `deep_merge` (list deduplication, parent-first ordering), so these paths stack correctly with remote URLs from other behaviors.

No module code changes needed.

## Changes

- `behaviors/skills.yaml` — Added `.amplifier/skills` and `~/.amplifier/skills` to the `config.skills` list