### PR TITLE
rename: debug → session-debug, simplify → code-review, batch → mass-change

### DIFF
--- a/context/skills-instructions.md
+++ b/context/skills-instructions.md
@@ -65,11 +65,11 @@ Three power skills ship with the curated collection. These are user-invoked via 
 
 | Skill | Slash Command | What It Does |
 |-------|--------------|--------------|
-| `simplify` | `/simplify [focus]` | Spawns 3 parallel review agents (code reuse, quality, efficiency) to review recent changes and apply fixes |
-| `batch` | `/batch <instruction>` | Decomposes a large change into 5–30 independent units, spawns parallel agents to implement each |
-| `debug` | `/debug [issue]` | Diagnoses session issues by delegating to the session-analyst agent |
+| `code-review` | `/code-review [focus]` | Spawns 3 parallel review agents (code reuse, quality, efficiency) to review recent changes and apply fixes |
+| `mass-change` | `/mass-change <instruction>` | Decomposes a large change into 5–30 independent units, spawns parallel agents to implement each |
+| `session-debug` | `/session-debug [issue]` | Diagnoses session issues by delegating to the session-analyst agent |
 
-These skills have `disable-model-invocation: true`, meaning they won't appear in the automatic skills visibility list. They are invoked by the user explicitly — via slash command (`/debug`, `/simplify`, `/batch`) or by calling `load_skill(skill_name="debug")` directly. When the user types one of these slash commands, load and execute the corresponding skill.
+These skills have `disable-model-invocation: true`, meaning they won't appear in the automatic skills visibility list. They are invoked by the user explicitly — via slash command (`/session-debug`, `/code-review`, `/mass-change`) or by calling `load_skill(skill_name="session-debug")` directly. When the user types one of these slash commands, load and execute the corresponding skill.
 
 ## Skills Discovery
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: simplify
+name: code-review
 description: "Review changed code for reuse, quality, and efficiency, then fix any issues found."
 context: fork
 disable-model-invocation: true

--- a/skills/mass-change/SKILL.md
+++ b/skills/mass-change/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: batch
+name: mass-change
 description: "Research and plan a large-scale change, then execute it in parallel across isolated agents that each open a PR."
 context: fork
 disable-model-invocation: true
@@ -27,16 +27,16 @@ If `$ARGUMENTS` is empty or was not provided, output exactly this and stop:
 Provide an instruction describing the batch change you want to make.
 
 Examples:
-  /batch migrate from react to vue
-  /batch replace all uses of lodash with native equivalents
-  /batch add type annotations to all untyped function parameters
+  /mass-change migrate from react to vue
+  /mass-change replace all uses of lodash with native equivalents
+  /mass-change add type annotations to all untyped function parameters
 ```
 
 **Check 2 — Git repository.**
 Run `git rev-parse --is-inside-work-tree` in the current directory. If it fails or returns an error, output exactly this and stop:
 
 ```
-This is not a git repository. The /batch skill requires a git repo because it spawns agents in isolated branches and creates PRs from each. Initialize a repo first, or run this from inside an existing one.
+This is not a git repository. The /mass-change skill requires a git repo because it spawns agents in isolated branches and creates PRs from each. Initialize a repo first, or run this from inside an existing one.
 ```
 
 If both checks pass, proceed with the three phases below.
@@ -88,7 +88,7 @@ For each agent, the prompt must be fully self-contained. Include:
 ### Worker Instructions
 
 After you finish implementing the change:
-1. **Simplify** — Invoke the /simplify skill to review and clean up your changes.
+1. **Code Review** — Invoke the /code-review skill to review and clean up your changes.
 2. **Run unit tests** — Run the project's test suite (check for package.json scripts, Makefile targets, or common commands like `npm test`, `bun test`, `pytest`, `go test`). If tests fail, fix them.
 3. **Test end-to-end** — Follow the verification recipe from the coordinator's prompt. If the recipe says to skip e2e for this unit, skip it.
 4. **Commit and push** — Commit all changes with a clear message, push the branch, and create a PR with `gh pr create`. Use a descriptive title. If `gh` is not available or the push fails, note it in your final message.

--- a/skills/session-debug/SKILL.md
+++ b/skills/session-debug/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: debug
+name: session-debug
 description: "Diagnose issues in the current Amplifier session — misconfigured tools, failing operations, unexpected behavior. Use when something isn't working right."
 context: fork
 disable-model-invocation: true


### PR DESCRIPTION
## Summary

Renames the three power skills to avoid naming collisions and improve clarity.

| Old Name | New Name | Reason |
|----------|----------|--------|
| `/debug` | `/session-debug` | Avoids collision with Superpowers `/debug` mode (debugging methodology vs session diagnostics) |
| `/simplify` | `/code-review` | More descriptive -- it's a 3-agent parallel code review, not a generic simplification |
| `/batch` | `/mass-change` | More descriptive -- it orchestrates a large-scale code change across parallel agents |

### Changes
- Renamed skill directories (`skills/debug/` → `skills/session-debug/`, etc.)
- Updated `name:` frontmatter field in each SKILL.md
- Updated cross-references in SKILL.md bodies (`/batch` → `/mass-change`, `/simplify` → `/code-review`)
- Updated `context/skills-instructions.md` table and slash command references

No functional changes -- pure rename.