### PR TITLE
fix: guard orchestrator string check to prevent AttributeError in protocol_compliance

### DIFF
--- a/modules/tool-skills/amplifier_module_tool_skills/__init__.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/__init__.py
@@ -156,11 +156,13 @@ async def mount(
         # Handles spawners that pass the flag via orchestrator_config but have not yet
         # registered it as a capability.
         # The spawner stores it at config["session"]["orchestrator"]["config"].
+        # NOTE: orchestrator can be a plain string ("loop-streaming") or an expanded dict
+        # ({"module": "loop-streaming", "config": {...}}). Guard with isinstance before
+        # chaining .get("config", ...) to avoid 'str' object has no attribute 'get'.
+        _orch = coordinator.config.get("session", {}).get("orchestrator", {})
         _is_forked_session = bool(
-            coordinator.config.get("session", {})
-            .get("orchestrator", {})
-            .get("config", {})
-            .get("_is_forked_skill_session", False)
+            isinstance(_orch, dict)
+            and _orch.get("config", {}).get("_is_forked_skill_session", False)
         )
     tool._is_forked_session = _is_forked_session
     if _is_forked_session:

--- a/modules/tool-skills/tests/test_coordinator_integration.py
+++ b/modules/tool-skills/tests/test_coordinator_integration.py
@@ -369,3 +369,32 @@ user_invocable: true
         if e[0] == "skill:command_registered"
     ]
     assert len(command_registered_events) == 0
+
+
+@pytest.mark.asyncio
+async def test_mount_with_string_orchestrator_config(tmp_path):
+    """Test that mount() does not crash when session.orchestrator is a plain string.
+
+    Regression test for: 'str' object has no attribute 'get' in protocol_compliance check.
+    The orchestrator config field supports two forms:
+      - Simple string: "loop-streaming"
+      - Expanded dict:  {"module": "loop-streaming", "config": {...}}
+    The forked-session detection fallback must handle both forms.
+    """
+    coordinator = MockCoordinator()
+    # Set orchestrator as a plain string (the most common real-world form).
+    # Previously this caused AttributeError: 'str' object has no attribute 'get'
+    coordinator.config = {
+        "session": {
+            "orchestrator": "loop-streaming",  # string form — NOT a dict
+        }
+    }
+
+    config = {"skills_dir": str(tmp_path)}
+    # Must not raise
+    await mount(coordinator, config)
+
+    # Session should not be detected as a forked skill session
+    tool = coordinator.mounted_tools.get("skills")
+    assert tool is not None
+    assert tool._is_forked_session is False


### PR DESCRIPTION
## Summary

Fixed a bug in the forked-session detection code where it crashed with `'str' object has no attribute 'get'` during module validation (protocol_compliance check).

- Added `isinstance(_orch, dict)` guard to safely handle both string and dict forms of the orchestrator config
- Added regression test `test_mount_with_string_orchestrator_config` to prevent future regressions

## Root Cause

The `session.orchestrator` config field supports two forms:
1. Simple string: `"loop-streaming"` (most common)
2. Expanded dict: `{"module": "loop-streaming", "config": {...}}`

The fallback detection code at lines ~159-164 in `__init__.py` assumed the dict form and called `.get("config", {})` directly. When `orchestrator` was a plain string (e.g., in `MockCoordinator` used by protocol_compliance validation), it crashed with `AttributeError: 'str' object has no attribute 'get'`.

## Changes

1. **modules/tool-skills/amplifier_module_tool_skills/__init__.py**
   - Extract `_orch = ...get("orchestrator", {})` first
   - Add `isinstance(_orch, dict)` guard before chaining `.get("config", ...)`
   - Add clarifying comments

2. **modules/tool-skills/tests/test_coordinator_integration.py**
   - Added `test_mount_with_string_orchestrator_config` regression test
   - Verifies mount() doesn't crash when orchestrator is a string
   - Tests that forked-session detection still works correctly

## Test Plan

- [x] Regression test added and passes
- [x] Existing tests still pass
- [x] Protocol compliance validation no longer crashes

Generated with Amplifier