### PR TITLE
fix: align README Trademarks section with canonical

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,6 @@ trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.
-
 ## License
 
 MIT - See [LICENSE](LICENSE)


### PR DESCRIPTION
## Summary

Aligns the README `## Trademarks` section byte-exactly with the canonical version in `microsoft/amplifier-core`. The only difference was one extra blank line within the section; this PR removes it.

## Why

Audit comparison against canonical was flagging this 1-line cosmetic difference. Aligning with canonical eliminates the false-flag noise. Rendered content is unchanged.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
