### PR TITLE
fix(tool-skills): include runtime_skill_overlay in search and list operations (#233)

### DIFF
--- a/modules/tool-skills/amplifier_module_tool_skills/__init__.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/__init__.py
@@ -13,11 +13,17 @@ from typing import TYPE_CHECKING, Any
 
 from amplifier_core import ToolResult
 
+try:
+    from amplifier_foundation import RUNTIME_SKILL_OVERLAY_CAPABILITY
+except ImportError:  # foundation not installed in all deployment configs
+    RUNTIME_SKILL_OVERLAY_CAPABILITY = "runtime_skill_overlay"  # type: ignore[assignment]
+
 from amplifier_module_tool_skills.discovery import SkillMetadata
 from amplifier_module_tool_skills.discovery import discover_skills
 from amplifier_module_tool_skills.discovery import discover_skills_multi_source
 from amplifier_module_tool_skills.discovery import extract_skill_body
 from amplifier_module_tool_skills.discovery import get_default_skills_dirs
+from amplifier_module_tool_skills.discovery import parse_skill_frontmatter
 from amplifier_module_tool_skills.model_resolver import resolve_skill_model
 from amplifier_module_tool_skills.preprocessing import preprocess
 from amplifier_module_tool_skills.sources import is_remote_source
@@ -590,16 +596,68 @@ Skill Discovery:
 
         return await self._load_skill(skill_name)
 
+    def _get_overlay_skill_metadata(self) -> dict[str, SkillMetadata]:
+        """Resolve runtime-overlay skills into searchable metadata.
+
+        Reads the `runtime_skill_overlay` coordinator capability — a producer-
+        neutral contract. Any bundle that wants to overlay additional skills at
+        runtime writes to it. tool-skills doesn't need to know who's writing.
+
+        Per-URI failures are logged at DEBUG; one bad URI never blocks the
+        others. Local skills shadow overlay skills (first-match-wins). Among
+        overlay URIs, first match also wins.
+
+        Issue #233: contributes.skills from active modes propagate via this
+        capability; propagation to sub-sessions happens in spawn_sub_session.
+        """
+        if not self.coordinator:
+            return {}
+        uris = self.coordinator.get_capability(RUNTIME_SKILL_OVERLAY_CAPABILITY) or []
+        if not uris:
+            return {}
+        resolver = self.coordinator.get_capability("mention_resolver")
+        if resolver is None:
+            return {}
+        overlay: dict[str, SkillMetadata] = {}
+        for uri in uris:
+            try:
+                resolved = resolver.resolve(uri)
+                if resolved is None:
+                    continue
+                resolved_path = Path(resolved)
+                skill_file = resolved_path / "SKILL.md"
+                if not skill_file.exists():
+                    continue
+                fm = parse_skill_frontmatter(skill_file)
+                if not fm:
+                    continue
+                name, description = fm.get("name"), fm.get("description")
+                if not name or not description:
+                    continue
+                # Local skills shadow overlay; first overlay wins on conflict.
+                if name in self.skills or name in overlay:
+                    continue
+                overlay[name] = SkillMetadata(
+                    name=name,
+                    description=description,
+                    path=skill_file,
+                    source=str(resolved_path),
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("Failed to resolve overlay skill URI %r: %s", uri, exc)
+        return overlay
+
     def _list_skills(self) -> ToolResult:
-        """List all available skills."""
-        if not self.skills:
+        """List all available skills (local + runtime overlay)."""
+        effective_skills = {**self.skills, **self._get_overlay_skill_metadata()}
+        if not effective_skills:
             sources = ", ".join(str(d) for d in self.skills_dirs)
             return ToolResult(
                 success=True, output={"message": f"No skills found in {sources}"}
             )
 
         skills_list = []
-        for name, metadata in sorted(self.skills.items()):
+        for name, metadata in sorted(effective_skills.items()):
             skills_list.append({"name": name, "description": metadata.description})
 
         lines = ["Available Skills:", ""]
@@ -611,9 +669,10 @@ Skill Discovery:
         )
 
     def _search_skills(self, search_term: str) -> ToolResult:
-        """Search skills by name or description."""
+        """Search skills by name or description (across local + overlay)."""
+        effective_skills = {**self.skills, **self._get_overlay_skill_metadata()}
         matches = {}
-        for name, metadata in self.skills.items():
+        for name, metadata in effective_skills.items():
             if (
                 search_term.lower() in name.lower()
                 or search_term.lower() in metadata.description.lower()
@@ -811,7 +870,8 @@ Skill Discovery:
                     logger.debug(
                         "Fork skill %r has model_role %r but no model_role_resolver "
                         "capability is registered; falling through to parent default provider",
-                        skill_name, resolved_model_role,
+                        skill_name,
+                        resolved_model_role,
                     )
 
             # 4. Get spawn function and related context (matching delegate tool pattern)

--- a/modules/tool-skills/tests/test_overlay_skills_search.py
+++ b/modules/tool-skills/tests/test_overlay_skills_search.py
@@ -8,8 +8,6 @@ mention_resolver resolves to skill directories at query time.
 
 from pathlib import Path
 
-import pytest
-
 from amplifier_module_tool_skills import SkillsTool
 from amplifier_module_tool_skills.discovery import SkillMetadata
 
@@ -19,14 +17,14 @@ RUNTIME_SKILL_OVERLAY_CAPABILITY = "runtime_skill_overlay"
 class MockCoordinator:
     """Minimal mock coordinator for overlay-skills tests."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.capabilities: dict = {}
         self.config: dict = {}
 
-    def register_capability(self, name: str, value) -> None:
+    def register_capability(self, name: str, value: object) -> None:
         self.capabilities[name] = value
 
-    def get_capability(self, name: str):
+    def get_capability(self, name: str) -> object:
         return self.capabilities.get(name)
 
 
@@ -65,10 +63,11 @@ def test_overlay_skill_appears_in_list_skills(tmp_path: Path) -> None:
         "mention_resolver", MockResolver({uri: str(skill_dir)})
     )
 
-    tool = SkillsTool({}, coordinator, [])  # no local skill dirs
+    tool = SkillsTool({}, coordinator, [])  # type: ignore[arg-type]
     result = tool._list_skills()
 
     assert result.success
+    assert result.output is not None
     assert "overlay-skill-a" in result.output["message"]
     skill_names = [s["name"] for s in result.output["skills"]]
     assert "overlay-skill-a" in skill_names
@@ -86,10 +85,11 @@ def test_overlay_skill_found_by_search_skills(tmp_path: Path) -> None:
         "mention_resolver", MockResolver({uri: str(skill_dir)})
     )
 
-    tool = SkillsTool({}, coordinator, [])
+    tool = SkillsTool({}, coordinator, [])  # type: ignore[arg-type]
     result = tool._search_skills("overlay-skill-b")
 
     assert result.success
+    assert result.output is not None
     assert "matches" in result.output
     match_names = [m["name"] for m in result.output["matches"]]
     assert "overlay-skill-b" in match_names
@@ -114,7 +114,7 @@ def test_local_skills_shadow_overlay_on_conflict(tmp_path: Path) -> None:
         "mention_resolver", MockResolver({uri: str(overlay_dir)})
     )
 
-    tool = SkillsTool({}, coordinator, [])
+    tool = SkillsTool({}, coordinator, [])  # type: ignore[arg-type]
     # Inject a "local" skill with the same name directly (simulates static
     # mount-time discovery; local skills are first-match-wins over overlay).
     local_skill_path = tmp_path / "local" / "SKILL.md"
@@ -130,15 +130,18 @@ def test_local_skills_shadow_overlay_on_conflict(tmp_path: Path) -> None:
     result = tool._list_skills()
 
     assert result.success
+    assert result.output is not None
     skill_names = [s["name"] for s in result.output["skills"]]
     assert conflict_name in skill_names
 
     # Verify the LOCAL description wins, not the overlay's
-    winning_entry = next(s for s in result.output["skills"] if s["name"] == conflict_name)
+    winning_entry = next(
+        s for s in result.output["skills"] if s["name"] == conflict_name
+    )
     assert winning_entry["description"] == "Local description — this wins"
 
 
-def test_no_overlay_capability_baseline(tmp_path: Path) -> None:
+def test_no_overlay_capability_baseline(tmp_path: Path) -> None:  # noqa: ARG001
     """Without runtime_skill_overlay capability, list and search work as before.
 
     No coordinator, or coordinator without the capability, must not break
@@ -146,7 +149,7 @@ def test_no_overlay_capability_baseline(tmp_path: Path) -> None:
     """
     # Case 1: coordinator present but capability NOT registered
     coordinator = MockCoordinator()
-    tool = SkillsTool({}, coordinator, [])
+    tool = SkillsTool({}, coordinator, [])  # type: ignore[arg-type]
     result = tool._list_skills()
     # No skills → empty-skills path (success, no crash)
     assert result.success

--- a/modules/tool-skills/tests/test_overlay_skills_search.py
+++ b/modules/tool-skills/tests/test_overlay_skills_search.py
@@ -1,0 +1,161 @@
+"""Tests for runtime_skill_overlay capability in search and list operations.
+
+Issue #233: mode-contributed skills via contributes.skills must be discoverable
+by tool-skills in both list and search operations. The bridge is the
+`runtime_skill_overlay` coordinator capability — a list of URIs that the
+mention_resolver resolves to skill directories at query time.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from amplifier_module_tool_skills import SkillsTool
+from amplifier_module_tool_skills.discovery import SkillMetadata
+
+RUNTIME_SKILL_OVERLAY_CAPABILITY = "runtime_skill_overlay"
+
+
+class MockCoordinator:
+    """Minimal mock coordinator for overlay-skills tests."""
+
+    def __init__(self):
+        self.capabilities: dict = {}
+        self.config: dict = {}
+
+    def register_capability(self, name: str, value) -> None:
+        self.capabilities[name] = value
+
+    def get_capability(self, name: str):
+        return self.capabilities.get(name)
+
+
+class MockResolver:
+    """Resolve @uri strings to local directory paths for testing."""
+
+    def __init__(self, mapping: dict[str, str]) -> None:
+        self._mapping = mapping
+
+    def resolve(self, uri: str) -> str | None:
+        return self._mapping.get(uri)
+
+
+def _make_overlay_skill_dir(
+    tmp_path: Path, name: str, description: str
+) -> tuple[Path, str]:
+    """Write a SKILL.md to tmp_path/<name>/ and return (skill_dir, uri)."""
+    skill_dir = tmp_path / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\nSkill body.\n"
+    )
+    uri = f"@overlay:{name}"
+    return skill_dir, uri
+
+
+def test_overlay_skill_appears_in_list_skills(tmp_path: Path) -> None:
+    """Overlay skill from runtime_skill_overlay capability appears in _list_skills."""
+    skill_dir, uri = _make_overlay_skill_dir(
+        tmp_path, "overlay-skill-a", "An overlay skill for testing"
+    )
+
+    coordinator = MockCoordinator()
+    coordinator.register_capability(RUNTIME_SKILL_OVERLAY_CAPABILITY, [uri])
+    coordinator.register_capability(
+        "mention_resolver", MockResolver({uri: str(skill_dir)})
+    )
+
+    tool = SkillsTool({}, coordinator, [])  # no local skill dirs
+    result = tool._list_skills()
+
+    assert result.success
+    assert "overlay-skill-a" in result.output["message"]
+    skill_names = [s["name"] for s in result.output["skills"]]
+    assert "overlay-skill-a" in skill_names
+
+
+def test_overlay_skill_found_by_search_skills(tmp_path: Path) -> None:
+    """Overlay skill is found when searching by name via _search_skills."""
+    skill_dir, uri = _make_overlay_skill_dir(
+        tmp_path, "overlay-skill-b", "An overlay skill for searching"
+    )
+
+    coordinator = MockCoordinator()
+    coordinator.register_capability(RUNTIME_SKILL_OVERLAY_CAPABILITY, [uri])
+    coordinator.register_capability(
+        "mention_resolver", MockResolver({uri: str(skill_dir)})
+    )
+
+    tool = SkillsTool({}, coordinator, [])
+    result = tool._search_skills("overlay-skill-b")
+
+    assert result.success
+    assert "matches" in result.output
+    match_names = [m["name"] for m in result.output["matches"]]
+    assert "overlay-skill-b" in match_names
+
+
+def test_local_skills_shadow_overlay_on_conflict(tmp_path: Path) -> None:
+    """Local skill named X shadows an overlay skill with the same name X.
+
+    _get_overlay_skill_metadata() skips any URI that resolves to a skill
+    already present in self.skills. The local (static) version wins.
+    """
+    conflict_name = "conflict-skill"
+
+    # Create the overlay version of the skill on disk
+    overlay_dir, uri = _make_overlay_skill_dir(
+        tmp_path, conflict_name, "Overlay description — should not win"
+    )
+
+    coordinator = MockCoordinator()
+    coordinator.register_capability(RUNTIME_SKILL_OVERLAY_CAPABILITY, [uri])
+    coordinator.register_capability(
+        "mention_resolver", MockResolver({uri: str(overlay_dir)})
+    )
+
+    tool = SkillsTool({}, coordinator, [])
+    # Inject a "local" skill with the same name directly (simulates static
+    # mount-time discovery; local skills are first-match-wins over overlay).
+    local_skill_path = tmp_path / "local" / "SKILL.md"
+    local_skill_path.parent.mkdir(parents=True)
+    local_skill_path.write_text("")
+    tool.skills[conflict_name] = SkillMetadata(
+        name=conflict_name,
+        description="Local description — this wins",
+        path=local_skill_path,
+        source="local",
+    )
+
+    result = tool._list_skills()
+
+    assert result.success
+    skill_names = [s["name"] for s in result.output["skills"]]
+    assert conflict_name in skill_names
+
+    # Verify the LOCAL description wins, not the overlay's
+    winning_entry = next(s for s in result.output["skills"] if s["name"] == conflict_name)
+    assert winning_entry["description"] == "Local description — this wins"
+
+
+def test_no_overlay_capability_baseline(tmp_path: Path) -> None:
+    """Without runtime_skill_overlay capability, list and search work as before.
+
+    No coordinator, or coordinator without the capability, must not break
+    existing behavior. This is the regression guard for the no-mode case.
+    """
+    # Case 1: coordinator present but capability NOT registered
+    coordinator = MockCoordinator()
+    tool = SkillsTool({}, coordinator, [])
+    result = tool._list_skills()
+    # No skills → empty-skills path (success, no crash)
+    assert result.success
+
+    # Case 2: no coordinator at all
+    tool_no_coord = SkillsTool({}, None, [])
+    result2 = tool_no_coord._list_skills()
+    assert result2.success
+
+    # Case 3: search also works cleanly with no overlay
+    result3 = tool._search_skills("anything")
+    assert result3.success


### PR DESCRIPTION
## Summary

`load_skill(search=...)` and `_list_skills` now consult the `runtime_skill_overlay` coordinator capability, so mode-contributed skills are discoverable via search/list, not only via direct URI.

Companion to:
- microsoft/amplifier-foundation#203 (capability rename + constant export, merged)
- microsoft/amplifier-app-cli#<NUMBER> (propagates the capability to child coordinators on spawn)

Part of microsoft-amplifier/amplifier-support#233 fix set.

## Changes

- `modules/tool-skills/amplifier_module_tool_skills/__init__.py`:
  - Imports `RUNTIME_SKILL_OVERLAY_CAPABILITY` from amplifier_foundation (with try/except fallback to the literal string for graceful degradation if running against an older foundation)
  - New `_get_overlay_skill_metadata()` reads the capability, resolves URIs via `mention_resolver`, parses SKILL.md frontmatter, returns dict
  - Per-URI failures logged at DEBUG; one bad URI doesn't block others
  - Local skills win on name conflict (first-match-wins between overlays)
  - `_list_skills` and `_search_skills` build `effective = {**self.skills, **self._get_overlay_skill_metadata()}` before any filtering

## Test plan

- [x] 4 new tests in `test_overlay_skills_search.py`:
  - Overlay skill appears in `_list_skills` result — RED→GREEN
  - `_search_skills` matches overlay skill — RED→GREEN
  - Local skills shadow overlay on conflict — passes before and after (regression guard)
  - No-overlay baseline — passes before and after (regression guard)
- [x] 229/230 skills bundle tests green (one pre-existing failure in `test_fork_skill_model_resolver_called_with_metadata_fields` predates this PR and is out of scope)
- [x] End-to-end validated in DTU: sub-session under active mode calls `load_skill(search="runtime-fix")` and finds the contributed skill (see issue #233 reply)

Closes: nothing directly; this is a companion to the foundation rename PR. Issue #233 is closed by the four-PR set together.
