### PR TITLE
chore: release v1.1.0

### DIFF
--- a/bundle.md
+++ b/bundle.md
@@ -1,7 +1,7 @@
 ---
 bundle:
   name: skills
-  version: 1.0.0
+  version: 1.1.0
   description: Skills tool and Microsoft-curated skills collection for Amplifier agents
 
 includes:

--- a/modules/tool-skills/amplifier_module_tool_skills/__init__.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/__init__.py
@@ -205,6 +205,7 @@ async def mount(
             visibility_config,
             is_forked_session=_is_forked_session,
             coordinator=coordinator,
+            tool=tool,
         )
 
         # Register hook on provider:request event; capture unregister callable
@@ -596,6 +597,20 @@ Skill Discovery:
 
         return await self._load_skill(skill_name)
 
+    def get_effective_skills(self) -> dict[str, SkillMetadata]:
+        """Return the merged static + runtime-overlay skill catalog.
+
+        Local (mount-time discovered) skills shadow overlay skills
+        (first-match-wins). Safe to call any time — overlay resolution
+        happens at call time, so the returned dict reflects the
+        coordinator's current `runtime_skill_overlay` capability state.
+
+        All entry points (load, info, list, search, visibility hook)
+        should resolve through this method so contributed skills are
+        consistently discoverable while the contributing mode is active.
+        """
+        return {**self.skills, **self._get_overlay_skill_metadata()}
+
     def _get_overlay_skill_metadata(self) -> dict[str, SkillMetadata]:
         """Resolve runtime-overlay skills into searchable metadata.
 
@@ -649,7 +664,7 @@ Skill Discovery:
 
     def _list_skills(self) -> ToolResult:
         """List all available skills (local + runtime overlay)."""
-        effective_skills = {**self.skills, **self._get_overlay_skill_metadata()}
+        effective_skills = self.get_effective_skills()
         if not effective_skills:
             sources = ", ".join(str(d) for d in self.skills_dirs)
             return ToolResult(
@@ -670,7 +685,7 @@ Skill Discovery:
 
     def _search_skills(self, search_term: str) -> ToolResult:
         """Search skills by name or description (across local + overlay)."""
-        effective_skills = {**self.skills, **self._get_overlay_skill_metadata()}
+        effective_skills = self.get_effective_skills()
         matches = {}
         for name, metadata in effective_skills.items():
             if (
@@ -695,9 +710,15 @@ Skill Discovery:
         )
 
     def _get_skill_info(self, skill_name: str) -> ToolResult:
-        """Get metadata for a skill without loading full content."""
-        if skill_name not in self.skills:
-            available = ", ".join(sorted(self.skills.keys()))
+        """Get metadata for a skill without loading full content.
+
+        Consults both local and runtime-overlay skills via
+        get_effective_skills(); contributed skills from active modes
+        are discoverable here.
+        """
+        effective_skills = self.get_effective_skills()
+        if skill_name not in effective_skills:
+            available = ", ".join(sorted(effective_skills.keys()))
             return ToolResult(
                 success=False,
                 error={
@@ -705,7 +726,7 @@ Skill Discovery:
                 },
             )
 
-        metadata = self.skills[skill_name]
+        metadata = effective_skills[skill_name]
         info = {
             "name": metadata.name,
             "description": metadata.description,
@@ -722,9 +743,15 @@ Skill Discovery:
         return ToolResult(success=True, output=info)
 
     async def _load_skill(self, skill_name: str) -> ToolResult:
-        """Load full skill content."""
-        if skill_name not in self.skills:
-            available = ", ".join(sorted(self.skills.keys()))
+        """Load full skill content.
+
+        Consults both local and runtime-overlay skills via
+        get_effective_skills(); contributed skills from active modes
+        are loadable here.
+        """
+        effective_skills = self.get_effective_skills()
+        if skill_name not in effective_skills:
+            available = ", ".join(sorted(effective_skills.keys()))
             return ToolResult(
                 success=False,
                 error={
@@ -732,7 +759,7 @@ Skill Discovery:
                 },
             )
 
-        metadata = self.skills[skill_name]
+        metadata = effective_skills[skill_name]
         body = extract_skill_body(metadata.path)
 
         if not body:

--- a/modules/tool-skills/amplifier_module_tool_skills/hooks.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/hooks.py
@@ -27,11 +27,14 @@ class SkillsVisibilityHook:
         config: dict[str, Any],
         is_forked_session: bool = False,
         coordinator: "ModuleCoordinator | None" = None,
+        tool: Any = None,
     ):
         """Initialize hook with skills data from tool.
 
         Args:
-            skills: Dictionary of discovered skills (from SkillsTool.skills)
+            skills: Dictionary of discovered skills (from SkillsTool.skills).
+                Used as fallback when ``tool`` is not provided (e.g. legacy
+                callers and unit tests).
             config: Hook configuration from visibility section
             is_forked_session: When True, fork-context skills are omitted from the
                 injected list.  This prevents the LLM inside a forked sub-session
@@ -39,8 +42,15 @@ class SkillsVisibilityHook:
                 would cause infinite recursion.
             coordinator: Optional module coordinator for capability-based fallback
                 detection of forked session state (defense-in-depth).
+            tool: Optional ``SkillsTool`` reference. When provided, the hook
+                uses ``tool.get_effective_skills()`` to obtain the merged static
+                + runtime-overlay catalog on every request, so mode-contributed
+                skills become visible while the contributing mode is active.
+                When omitted, the hook falls back to ``skills`` (a static dict
+                with no overlay merge). Production mount path supplies it; some
+                unit tests do not.
         """
-        self.skills = skills  # Reference to tool's skills dict
+        self.skills = skills  # Reference to tool's skills dict (legacy/fallback path)
         self.enabled = config.get("enabled", True)
         self.inject_role = config.get("inject_role", "system")
         self.max_visible = config.get("max_skills_visible", 50)
@@ -48,12 +58,31 @@ class SkillsVisibilityHook:
         self.priority = config.get("priority", 20)
         self._is_forked_session = is_forked_session
         self.coordinator = coordinator
+        self._tool = tool
 
         logger.debug(
             f"Initialized SkillsVisibilityHook: enabled={self.enabled}, "
             f"max_visible={self.max_visible}, ephemeral={self.ephemeral}, "
-            f"is_forked_session={self._is_forked_session}"
+            f"is_forked_session={self._is_forked_session}, "
+            f"tool_attached={self._tool is not None}"
         )
+
+    def _effective_skills(self) -> dict[str, Any]:
+        """Return the catalog the hook should render on this request.
+
+        Prefers ``tool.get_effective_skills()`` (static + overlay merge) when
+        a tool reference is attached; falls back to the static ``self.skills``
+        dict otherwise so legacy callers and unit tests keep working.
+        """
+        if self._tool is not None and hasattr(self._tool, "get_effective_skills"):
+            try:
+                return self._tool.get_effective_skills()
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(
+                    "tool.get_effective_skills() raised %s; falling back to static catalog",
+                    exc,
+                )
+        return self.skills
 
     async def on_provider_request(self, event: str, data: dict[str, Any]) -> HookResult:
         """Inject skills list before LLM request.
@@ -68,10 +97,14 @@ class SkillsVisibilityHook:
             HookResult with action="inject_context" if skills should be shown,
             or action="continue" if disabled or no skills available
         """
-        if not self.enabled or not self.skills:
+        if not self.enabled:
             return HookResult(action="continue")
 
-        skills_text = self._format_skills_list()
+        effective = self._effective_skills()
+        if not effective:
+            return HookResult(action="continue")
+
+        skills_text = self._format_skills_list(effective)
 
         if not skills_text:
             return HookResult(action="continue")
@@ -84,7 +117,7 @@ class SkillsVisibilityHook:
             suppress_output=True,
         )
 
-    def _format_skills_list(self) -> str:
+    def _format_skills_list(self, skills: dict[str, Any] | None = None) -> str:
         """Format skills list as markdown with XML boundaries.
 
         Partitions skills into two sections:
@@ -93,10 +126,18 @@ class SkillsVisibilityHook:
         - User-invoked skills (disable_model_invocation=True): shown under 'User-invoked
           skills' with no cap
 
+        Args:
+            skills: Optional catalog dict to render. Defaults to the
+                effective-skills view (static + overlay merge). Passing
+                an explicit dict supports legacy test callers that
+                exercise the formatter in isolation.
+
         Returns:
             Formatted skills list string, or empty string if no skills
         """
-        if not self.skills:
+        if skills is None:
+            skills = self._effective_skills()
+        if not skills:
             return ""
 
         # Partition skills into regular and user-invoked.
@@ -116,12 +157,12 @@ class SkillsVisibilityHook:
 
         regular_skills = {
             name: meta
-            for name, meta in self.skills.items()
+            for name, meta in skills.items()
             if not meta.disable_model_invocation and _keep(meta)
         }
         user_invoked_skills = {
             name: meta
-            for name, meta in self.skills.items()
+            for name, meta in skills.items()
             if meta.disable_model_invocation and _keep(meta)
         }
 

--- a/modules/tool-skills/tests/test_overlay_skills_search.py
+++ b/modules/tool-skills/tests/test_overlay_skills_search.py
@@ -162,3 +162,156 @@ def test_no_overlay_capability_baseline(tmp_path: Path) -> None:  # noqa: ARG001
     # Case 3: search also works cleanly with no overlay
     result3 = tool._search_skills("anything")
     assert result3.success
+
+
+# ============================================================================
+# Tests for full coverage of overlay-aware entry points
+# ============================================================================
+# Issue #233 part 2: list and search were the first entry points wired to
+# consult runtime_skill_overlay; load_skill, get_skill_info, and the
+# visibility hook also need to see overlay skills so a contributed skill
+# is consistently discoverable end-to-end while the contributing mode is
+# active.
+
+
+def test_overlay_skill_found_by_load_skill(tmp_path: Path) -> None:
+    """_load_skill resolves an overlay-only skill (not in local catalog).
+
+    Without overlay-awareness in _load_skill, load_skill(skill_name=...)
+    would return "not found" even though the skill is mounted via the
+    runtime_skill_overlay capability. This is the fix for the user-visible
+    'load_skill cannot find mode-contributed skill' bug.
+    """
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock
+
+    overlay_dir, uri = _make_overlay_skill_dir(
+        tmp_path, "overlay-loadable", "Loadable via overlay only"
+    )
+
+    coordinator = MockCoordinator()
+    coordinator.register_capability(RUNTIME_SKILL_OVERLAY_CAPABILITY, [uri])
+    coordinator.register_capability(
+        "mention_resolver", MockResolver({uri: str(overlay_dir)})
+    )
+    # _load_skill emits a 'skill:loaded' event via coordinator.hooks.emit
+    # after a successful load. Provide an async-compatible hooks mock so
+    # the test doesn't crash on the post-load notification.
+    coordinator.hooks = MagicMock()  # type: ignore[attr-defined]
+    coordinator.hooks.emit = AsyncMock()  # type: ignore[attr-defined]
+
+    tool = SkillsTool({}, coordinator, [])  # type: ignore[arg-type]
+    result = asyncio.run(tool._load_skill("overlay-loadable"))
+
+    assert result.success, f"Expected success, got error: {result.error}"
+    # The emit() call confirms the load reached the success path.
+    coordinator.hooks.emit.assert_awaited_once()  # type: ignore[attr-defined]
+    args, _ = coordinator.hooks.emit.call_args  # type: ignore[attr-defined]
+    assert args[0] == "skill:loaded"
+    assert args[1]["skill_name"] == "overlay-loadable"
+
+
+def test_overlay_skill_found_by_get_skill_info(tmp_path: Path) -> None:
+    """_get_skill_info resolves an overlay-only skill.
+
+    load_skill(info='name') must produce metadata for overlay skills, not
+    'not found'. Same fix as _load_skill, different entry point.
+    """
+    overlay_dir, uri = _make_overlay_skill_dir(
+        tmp_path, "overlay-infoable", "Info via overlay"
+    )
+
+    coordinator = MockCoordinator()
+    coordinator.register_capability(RUNTIME_SKILL_OVERLAY_CAPABILITY, [uri])
+    coordinator.register_capability(
+        "mention_resolver", MockResolver({uri: str(overlay_dir)})
+    )
+
+    tool = SkillsTool({}, coordinator, [])  # type: ignore[arg-type]
+    result = tool._get_skill_info("overlay-infoable")
+
+    assert result.success, f"Expected success, got error: {result.error}"
+    assert result.output is not None
+    assert result.output["name"] == "overlay-infoable"
+    assert result.output["description"] == "Info via overlay"
+
+
+def test_overlay_skill_load_skill_not_found_when_no_overlay(tmp_path: Path) -> None:  # noqa: ARG001
+    """_load_skill returns 'not found' for a skill absent from both catalogs.
+
+    Regression guard: the overlay-aware error path must still report
+    'not found' (with the merged available list) when the requested skill
+    truly does not exist anywhere.
+    """
+    import asyncio
+
+    coordinator = MockCoordinator()
+    tool = SkillsTool({}, coordinator, [])  # type: ignore[arg-type]
+    result = asyncio.run(tool._load_skill("nonexistent"))
+
+    assert not result.success
+    assert result.error is not None
+    assert "not found" in result.error["message"].lower()
+
+
+def test_visibility_hook_renders_overlay_skills(tmp_path: Path) -> None:
+    """SkillsVisibilityHook surfaces overlay skills when constructed with a tool.
+
+    The hook's job is to emit the available-skills system reminder on every
+    provider:request. Without tool-attached overlay merging, mode-contributed
+    skills are invisible to the LLM (the visibility hook only saw the static
+    mount-time catalog).
+    """
+    from amplifier_module_tool_skills.hooks import SkillsVisibilityHook
+
+    overlay_dir, uri = _make_overlay_skill_dir(
+        tmp_path, "overlay-visible", "Should appear in visibility output"
+    )
+
+    coordinator = MockCoordinator()
+    coordinator.register_capability(RUNTIME_SKILL_OVERLAY_CAPABILITY, [uri])
+    coordinator.register_capability(
+        "mention_resolver", MockResolver({uri: str(overlay_dir)})
+    )
+
+    tool = SkillsTool({}, coordinator, [])  # type: ignore[arg-type]
+
+    # Construct hook the way __init__.py mounts it now — with tool reference.
+    # type: ignore[call-arg] — pyright sometimes lags on freshly-added kwargs
+    hook = SkillsVisibilityHook(  # type: ignore[call-arg]
+        skills=tool.skills,
+        config={"enabled": True},
+        coordinator=coordinator,  # type: ignore[arg-type]
+        tool=tool,
+    )
+
+    rendered = hook._format_skills_list()
+    assert "overlay-visible" in rendered, (
+        f"Expected overlay-visible skill in rendered visibility output, got:\n{rendered}"
+    )
+    assert "Should appear in visibility output" in rendered
+
+
+def test_visibility_hook_legacy_path_unchanged(tmp_path: Path) -> None:  # noqa: ARG001
+    """Hook without `tool` keeps the legacy static-only behavior.
+
+    Backward-compatibility guard: many existing tests construct the hook
+    with just (skills, config). Those callers must not be required to pass
+    a tool reference. The hook should fall back to the static skills dict
+    when no tool is attached.
+    """
+    from amplifier_module_tool_skills.hooks import SkillsVisibilityHook
+    from amplifier_module_tool_skills.discovery import SkillMetadata
+
+    static_skills = {
+        "static-only": SkillMetadata(
+            name="static-only",
+            description="Static catalog entry",
+            path=Path("/nonexistent/SKILL.md"),
+            source="local",
+        )
+    }
+    hook = SkillsVisibilityHook(skills=static_skills, config={"enabled": True})
+
+    rendered = hook._format_skills_list()
+    assert "static-only" in rendered


### PR DESCRIPTION
## Summary

Closes issue #233 end-to-end by fixing mode-contributed skills visibility across all tool-skills entry points.

## What Changed

- **New `SkillsTool.get_effective_skills()` helper**: Returns the merged static + runtime-overlay skill catalog. All entry points now resolve through this single method.

- **Updated entry points** to use `get_effective_skills()`:
  - `_load_skill` — overlay-contributed skills now loadable
  - `_get_skill_info` — overlay skills now have queryable metadata
  - `_list_skills` — refactored to call the helper
  - `_search_skills` — refactored to call the helper

- **`SkillsVisibilityHook` gains optional `tool` parameter**: When provided (the production mount path does so), renders the per-request skills-visibility reminder with mode-contributed skills included. When omitted, falls back to static skills dict for backward compatibility.

- **5 new tests** in `tests/test_overlay_skills_search.py`:
  - `_load_skill` finds overlay skills
  - `_get_skill_info` finds overlay skills
  - `_load_skill` still reports not-found correctly when overlay is empty
  - Visibility hook renders overlay skills when given a tool
  - Visibility hook preserves legacy static-only behavior without a tool

All 9 tests in the overlay suite pass; all 36 existing hook + integration tests still pass.

## Impact

This is a backward-compatible MINOR release. Existing code that creates `SkillsVisibilityHook()` without the new `tool=` parameter continues to work exactly as before. New code using the hook via the production mount path gets full overlay visibility.

The fix resolves the long-standing gap where contributed skills were enumerable (`_list_skills`, `_search_skills`) but not loadable or visible in per-turn reminders to the LLM.

## Test Plan

- ✅ All 9 overlay tests pass (5 new + 4 pre-existing)
- ✅ All 36 hook + integration tests pass
- ✅ Backward compatibility preserved on hook constructor

---

Generated with [Amplifier](https://github.com/microsoft/amplifier)