### PR TITLE
feat(skills): add per-repo-conventions and verification-discipline skills

### DIFF
--- a/skills/per-repo-conventions/SKILL.md
+++ b/skills/per-repo-conventions/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: per-repo-conventions
+description: >
+  Use when starting work in any repository. Auto-surface when an agent is about
+  to write code, create a PR, or verify work. Teaches the discovery pattern for
+  finding and applying per-repo conventions (AGENTS.md, PR templates,
+  CONTRIBUTING.md) before acting.
+---
+
+# Per-Repo Conventions
+
+## The Principle
+
+When you work in a repo, you're a guest. The repo's owners maintain conventions
+that encode their experience — including bugs they have already paid for. Read
+those conventions before you act.
+
+The foundation/kernel layer defines philosophy. Individual repos define
+specifics. The kernel does not know what a particular repo's smoke test
+command is, what its PR checklist requires, or which gates its maintainers
+consider non-negotiable. The repo does. Honor it.
+
+## The Discovery Pattern
+
+At the start of any task that touches a repo, before writing code, walk this
+checklist:
+
+1. **`AGENTS.md`** — check the repo root first, then walk up from the current
+   working directory if you're working in a subdirectory. This is the
+   highest-signal file for agent behavior in this ecosystem.
+2. **`.github/PULL_REQUEST_TEMPLATE.md`** — check at repo root. This is the
+   checklist your PR must honor.
+3. **`CONTRIBUTING.md`** — check at repo root. General contribution
+   conventions.
+
+Skim each file that exists. Apply the relevant conventions to your work.
+
+## What Each File Contains
+
+- **`AGENTS.md`** — agent-facing conventions. Test commands, common pitfalls,
+  build steps, environment requirements, areas to avoid touching, and the
+  shape of "done" in this repo. Often the only place where tribal knowledge
+  is written down.
+- **`.github/PULL_REQUEST_TEMPLATE.md`** — the checklist that auto-populates
+  every PR body. Treat each checkbox as a required action, not a suggestion.
+- **`CONTRIBUTING.md`** — broader contributor guidance. Style, branching,
+  review process, sign-off requirements.
+
+## Applying Conventions
+
+- When the repo says "run X before merging," run X.
+- When the repo says "test with Y," use Y.
+- When your defaults contradict the repo, the repo wins.
+- Your PR body should reflect the repo's checklist — items checked, evidence
+  linked, not blank boxes.
+
+## What It Looks Like in Practice
+
+```
+I'm about to fix a bug in some-repo. Before writing code, I read:
+- some-repo/AGENTS.md
+    → "Smoke test required: ./scripts/smoke-test.sh on a fresh DTU"
+    → "Engine changes require a live pipeline run, not just unit tests"
+- some-repo/.github/PULL_REQUEST_TEMPLATE.md
+    → "[ ] Smoke test passed (link log)"
+    → "[ ] Live run exercising changed code path (link events.jsonl)"
+
+My plan:
+1. Implement the fix.
+2. Run unit tests (necessary, not sufficient).
+3. Run ./scripts/smoke-test.sh on a fresh DTU per AGENTS.md. Capture log.
+4. Run a live pipeline exercising the changed path. Capture events.jsonl.
+5. PR body addresses each checklist item explicitly with links to evidence.
+```
+
+The cost of this discovery pass is minutes. The cost of skipping it is the
+integration-blocking bug the repo's conventions were written to prevent.
+
+## Anti-Patterns
+
+- **Skipping AGENTS.md because "I know how to fix this."** You may know the
+  fix. You don't know the repo's gates. Read the file.
+- **Filling out the PR template with empty checkboxes.** An unchecked box on
+  a merged PR is a documented gap. Either do the work or remove the line.
+- **Treating the repo's gates as optional suggestions.** The gate is there
+  because someone already paid for the bug it prevents.
+- **Re-discovering bugs the repo's conventions were designed to prevent.**
+  If the checklist says "smoke test on fresh DTU" and you ship without one,
+  you will discover why the line exists.
+- **Working only from kernel/foundation docs.** Foundation can't name a
+  specific repo's gates. The repo can.
+
+## Cross-References
+
+- `foundation:docs/PER_REPO_CONVENTIONS.md` — canonical statement of the
+  principle.
+- `skills/verification-discipline/` — the complementary skill that explains
+  *why* per-repo gates (especially smoke and integration tests) matter and
+  what "verified" actually means.

--- a/skills/verification-discipline/SKILL.md
+++ b/skills/verification-discipline/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: verification-discipline
+description: >
+  Use when verifying that completed work actually works. Auto-surface during
+  /verify mode, post-implementation review, or before claiming a task is done.
+  Teaches the discipline of testing outcomes vs implementation, the
+  unit/integration/smoke gradient, and what "done" actually means.
+---
+
+# Verification Discipline
+
+## The Principle
+
+Unit tests verify that **code-as-written behaves as-written**. Smoke and
+integration tests verify that **the system achieves the intended outcome**.
+Those are different questions. You need both.
+
+"All unit tests pass" is necessary. It is rarely sufficient. A finding from
+the field: four consecutive integration-blocking bugs, all of which passed
+unit tests, all of which would have been caught by a five-minute smoke test
+on a fresh environment. The bugs were not exotic — they were the cost of
+declaring "done" too early.
+
+## The Four Failure Modes
+
+1. **Tests written from the implementation outward miss scenarios the code
+   doesn't anticipate.** The engineer writes code, then writes tests that
+   exercise the code as written. The tests ask "does this code do what I
+   wrote it to do?" They don't ask "what scenarios does the system need to
+   handle?"
+2. **Mocks verify shape, not behavior.** A mocked dependency returns the
+   value you told it to return. That tells you nothing about whether the
+   real dependency would have behaved that way.
+3. **Tests in isolation miss integration boundaries.** Component A passes.
+   Component B passes. Their interaction at the seam fails. The seam was
+   never tested.
+4. **Happy-path tests pass while activated code paths fail.** A
+   golden-file test verifies that the default (un-activated) configuration
+   renders correctly. The activated configuration — the one production
+   actually uses — was never exercised.
+
+## The Verification Gradient
+
+Treat verification as a ladder. Skip a rung and you discover its bugs in
+production.
+
+| Tier | What it verifies | Example |
+|---|---|---|
+| 1. Unit | Code does what I wrote it to do | `pytest tests/unit/` |
+| 2. Integration | Component pairs interact correctly | `pytest tests/integration/`, real DB |
+| 3. Smoke / E2E | System achieves the user-visible outcome | Fresh DTU launch, run real pipeline, observe artifacts |
+| 4. Production-equivalent | Real environment, real load, real data | Staging deployment, canary, replay traces |
+
+Each tier catches bugs the tier below it cannot. Each tier costs more time
+than the tier below it. The economic choice is not "skip the expensive
+tiers." The economic choice is "spend five minutes on tier 3 to avoid five
+hours of rollback."
+
+## What "Done" Actually Means
+
+Before claiming a task is done, satisfy this checklist:
+
+- [ ] Code does what I wrote it to do (unit tests pass).
+- [ ] Code interacts correctly with other components (integration tests
+      pass, or — if no integration tests exist for this code path — a
+      manual integration check is documented).
+- [ ] The system achieves the user-visible outcome (smoke or E2E test
+      passed, ideally on a fresh environment).
+- [ ] Repo-specific gates from `AGENTS.md` and `.github/PULL_REQUEST_TEMPLATE.md`
+      are satisfied.
+- [ ] Evidence is **observable** — log file, screenshot, output excerpt,
+      events.jsonl analysis. Not "tests pass." Not "looks right."
+
+If any box is unchecked, the work is not done. Say so, explicitly.
+
+## Tests-From-Outcomes Pattern
+
+Different from classic TDD. TDD writes unit tests first. Tests-from-outcomes
+writes the outcome assertion first.
+
+```
+1. Before writing implementation, write down the user-observable outcome.
+   "After running this pipeline, events.jsonl contains a `branch_completed`
+    event for each branch and no `contract_violation` events."
+
+2. Write a test asserting that outcome. The test runs the real pipeline,
+   inspects the real events.jsonl, checks the real conditions.
+
+3. Implement code until the test passes.
+```
+
+Both patterns are valuable. Unit-level TDD verifies internal correctness.
+Outcome-level testing verifies that the system behaves as the user expects.
+Use both.
+
+## Anti-Patterns
+
+- **"All unit tests pass, so we're done."** Usually wrong. The unit tests
+  verified the code you wrote. They did not verify the system you shipped.
+- **Mocking the very thing the test is supposed to verify.** If the
+  question is "does the database client retry correctly?" and you mock the
+  database client's retry method, you have tested nothing.
+- **Skipping smoke tests because they're slow.** A five-minute smoke test
+  is cheaper than a five-hour rollback.
+- **Verifying that the code compiles, not that it works.** "It builds"
+  ≠ "it runs." "It runs" ≠ "it does the right thing."
+- **Claiming "verified" without producing evidence.** Evidence is a log, a
+  screenshot, an artifact diff, an events.jsonl excerpt. "I checked" is
+  not evidence.
+- **Treating CI green as proof.** CI runs what CI is configured to run.
+  If CI has no integration tier, CI green tells you only that the unit
+  tier passed.
+
+## The Pattern That Emerged from the Field
+
+Four integration-blocking bugs in four consecutive shippings. All would have
+been caught by a smoke test on a fresh environment. None were caught by the
+unit tests that did exist, because the unit tests asked the wrong question.
+
+The fix:
+
+- Smoke test as a **PR gate**, not an aspiration.
+- The PR template encodes that gate — it auto-populates in every PR body.
+- Reviewers see unchecked boxes immediately and refuse to merge without
+  evidence linked next to each box.
+
+Cultural change is hard. Changing the form is easy. Change the form first.
+
+## Cross-References
+
+- `skills/per-repo-conventions/` — how to discover the specific gates a
+  given repo requires (AGENTS.md, PR template, CONTRIBUTING.md).
+- `foundation:docs/PER_REPO_CONVENTIONS.md` — canonical principle for
+  per-repo discovery.
+- `skills/integration-testing-discipline/` — concrete tactics for running
+  the integration tier (observe first, fix in batches, expect long
+  durations).


### PR DESCRIPTION
## Summary

- Adds `skills/per-repo-conventions/SKILL.md` (99 lines): auto-surfaces when an agent starts work in any repo; teaches the discovery pattern for `AGENTS.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `CONTRIBUTING.md`; explains why per-repo conventions exist and how to honor them
- Adds `skills/verification-discipline/SKILL.md` (137 lines): the retrospective's 4 failure modes + verification gradient (unit → smoke → integration) in reusable skill form; includes concrete examples from 4 integration-blocking bugs in 4 consecutive shippings; auto-surfaces when any verification or PR-creation work is happening

Layer 6 of the verification-discipline pilot. These two skills ensure future agents and contributors can discover the principle even if they haven't read the foundation docs — skills surface at invocation time, exactly when the guidance is needed.

## Test plan

- [x] Both `SKILL.md` files follow the Amplifier skill spec (frontmatter, content, examples)
- [x] `per-repo-conventions` skill correctly describes the discovery pattern as implemented in agent files (Layer 2)
- [x] `verification-discipline` skill's 4 failure modes match the actual bugs from this session
- [x] Skills load cleanly via `load_skill` (no syntax errors)

Generated with [Amplifier](https://github.com/microsoft/amplifier)
