### PR TITLE
fix(skills): restore SkillsDiscovery.get_shortcuts() deleted by malformed edit (PR #20 regression)

### DIFF
--- a/modules/tool-skills/amplifier_module_tool_skills/__init__.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/__init__.py
@@ -326,7 +326,30 @@ class SkillsDiscovery:
         """
         return self._skills.get(name)
 
+    def get_shortcuts(self) -> dict[str, dict[str, Any]]:
+        """Return dispatch entries for all user-invocable skills.
 
+        Each user-invocable skill gets an entry under its canonical name.
+        If the skill has a shortcut alias that differs from the canonical
+        name, the same entry is also registered under the alias.
+
+        Returns:
+            Dict mapping slash-command names (canonical + aliases) to
+            dispatch entry dicts with 'name', 'description', and 'context'.
+        """
+        shortcuts: dict[str, dict[str, Any]] = {}
+        for name, metadata in self._skills.items():
+            if not metadata.user_invocable:
+                continue
+            entry = {
+                "name": name,
+                "description": metadata.description,
+                "context": metadata.context,
+            }
+            shortcuts[name] = entry
+            if metadata.shortcut and metadata.shortcut != name:
+                shortcuts[metadata.shortcut] = entry
+        return shortcuts
 
 
 class SkillsTool:

--- a/modules/tool-skills/tests/test_skills_discovery.py
+++ b/modules/tool-skills/tests/test_skills_discovery.py
@@ -13,6 +13,7 @@ def _make_skill(
     description: str,
     user_invocable: bool = False,
     context: str | None = None,
+    shortcut: str | None = None,
 ) -> SkillMetadata:
     """Helper to create test SkillMetadata."""
     return SkillMetadata(
@@ -22,6 +23,7 @@ def _make_skill(
         source="/fake",
         user_invocable=user_invocable,
         context=context,
+        shortcut=shortcut,
     )
 
 
@@ -132,6 +134,53 @@ class TestSkillsDiscoveryGetShortcuts:
         discovery = SkillsDiscovery(skills)
         result = discovery.get_shortcuts()
         assert result == {}
+
+    # --- Required regression-guard tests ---
+
+    def test_method_exists_on_class(self):
+        """get_shortcuts exists on SkillsDiscovery and is callable."""
+        assert hasattr(SkillsDiscovery, "get_shortcuts")
+        assert callable(SkillsDiscovery({}).get_shortcuts)
+
+    def test_empty_skills_dict_returns_empty_dict(self):
+        """get_shortcuts() returns empty dict when skills dict is empty."""
+        assert SkillsDiscovery({}).get_shortcuts() == {}
+
+    def test_entry_has_name_key(self):
+        """Each shortcut entry dict contains the canonical 'name' key."""
+        skills = {
+            "foo": _make_skill("foo", "Foo skill", user_invocable=True),
+        }
+        discovery = SkillsDiscovery(skills)
+        result = discovery.get_shortcuts()
+        assert result["foo"]["name"] == "foo"
+
+    def test_shortcut_registers_alias_key(self):
+        """A skill with shortcut != name gets entries under both keys."""
+        skills = {
+            "cranky-old-sam": _make_skill(
+                "cranky-old-sam",
+                "Cranky reviewer",
+                user_invocable=True,
+                shortcut="cosam",
+            ),
+        }
+        discovery = SkillsDiscovery(skills)
+        result = discovery.get_shortcuts()
+        assert "cranky-old-sam" in result
+        assert "cosam" in result
+        assert result["cranky-old-sam"]["name"] == "cranky-old-sam"
+        assert result["cosam"]["name"] == "cranky-old-sam"
+
+    def test_shortcut_equal_to_canonical_name_is_idempotent(self):
+        """A skill with shortcut == name produces only one entry, no errors."""
+        skills = {
+            "foo": _make_skill("foo", "Foo skill", user_invocable=True, shortcut="foo"),
+        }
+        discovery = SkillsDiscovery(skills)
+        result = discovery.get_shortcuts()
+        assert len(result) == 1
+        assert "foo" in result
 
 
 class MockHooks:


### PR DESCRIPTION
## Summary

Restores `SkillsDiscovery.get_shortcuts()` which was accidentally deleted by a malformed `edit_file` call in the session that produced PR #20 (commit `183e0c0`). The tool used the wrong parameter name (`new_str` instead of `new_string`), deleted the original method body, and inserted nothing.

**Impact of the regression:**
- `/cranky-old-sam` → "Unknown command"
- `/cosam` → "Unknown command"
- Every `user-invocable: true` skill dropped from slash-command dispatch
- Power skills (`disable-model-invocation: true`) unaffected (different dispatch path)

## Changes

### `modules/tool-skills/amplifier_module_tool_skills/__init__.py`

Re-inserts `get_shortcuts()` at lines 329-351, between `find()` and `class SkillsTool`:

- Iterates `self._skills.items()`
- Skips skills where `metadata.user_invocable` is `False`
- Builds dispatch entry `{"name": name, "description": ..., "context": ...}`
- Registers entry under canonical `name`
- Also registers under `metadata.shortcut` when shortcut differs from name
- Return type: `dict[str, dict[str, Any]]` (`Any` was already imported)

### `modules/tool-skills/tests/test_skills_discovery.py`

Adds 5 regression-guard tests to `TestSkillsDiscoveryGetShortcuts` + updates `_make_skill` helper to accept `shortcut` parameter:

| Test | What it guards |
|---|---|
| `test_method_exists_on_class` | Class-level existence check — would have caught this regression |
| `test_empty_skills_dict_returns_empty_dict` | Empty dict fast-path |
| `test_entry_has_name_key` | Entry shape includes required `name` key |
| `test_shortcut_registers_alias_key` | `/cosam` → `cranky-old-sam` dispatch |
| `test_shortcut_equal_to_canonical_name_is_idempotent` | No duplicate entry when shortcut == name |

## Test results

**TDD sequence followed:**
1. Added new tests → all 10 `TestSkillsDiscoveryGetShortcuts` tests **failed** (method missing)
2. Implemented `get_shortcuts()` → all 19 tests in `test_skills_discovery.py` **pass**

Full suite (excluding pre-existing collection error for `test_fork_skill_model_role_resolver.py` — requires `amplifier_foundation` not installed in test venv):
```
2 failed, 236 passed
```
The 2 failures are pre-existing and unrelated to this change (verified by stash/unstash).

## Minimal change confirmation

- `git diff --stat`: 2 files, 72 insertions, 0 deletions
- No changes to `discovery.py`, no changes to any other module, no changes to app-cli
- Only the missing method body restored, plus tests