### PR TITLE
feat(skill): add shortcut: COE to crusty-old-engineer

### DIFF
--- a/skills/crusty-old-engineer/SKILL.md
+++ b/skills/crusty-old-engineer/SKILL.md
@@ -9,6 +9,7 @@ description: |
   Use when: architectural decisions, legacy replacements, new tooling evaluation, broad planning questions.
 allowed-tools: ["Read", "Grep", "Glob", "Bash", "WebSearch", "WebFetch", "Agent", "AskUserQuestion"]
 user-invocable: true
+shortcut: COE
 auto-activation:
   priority: 3
   keywords: ["crusty", "coe", "old engineer", "engineering judgment", "should I use", "is this a good idea", "what could go wrong", "reality check"]


### PR DESCRIPTION
## Summary

Adds `shortcut: COE` to the `crusty-old-engineer` skill, mirroring the `shortcut: COSam` alias on `cranky-old-sam` (shipped via [microsoft-amplifier/amplifier-bundle-made-support#15](https://github.com/microsoft-amplifier/amplifier-bundle-made-support/pull/15)).

After this lands, `/COE`, `/coe`, and any case variant resolve to the canonical `crusty-old-engineer` skill. The CLI lowercases all slash input before lookup, so case is irrelevant at invoke time. `/crusty-old-engineer` continues to work and remains the advertised name in `/skills` listings.

## Change

One line added to `skills/crusty-old-engineer/SKILL.md` frontmatter immediately after `user-invocable: true`:

```yaml
shortcut: COE
```

## Why only this one

The session's persona-as-tone skills (`cranky-old-sam`, `crusty-old-engineer`) are the genuine "every-turn during sustained work" use case the `shortcut:` mechanism was built for. Walking the rest of the skill catalog against that bar:

- **Process skills** (`brainstorming`, `executing-plans`, `subagent-driven-development`, etc.): loaded once per work session. No keystroke savings worth it.
- **Domain reference skills** (`architecture-primitives`, `design-philosophy-*`, `resolve-*`, `dot-*`, etc.): consulted ad hoc, not invoked every turn.
- **Meta-skills** (`skills-assist`, `skillify`, `adapt-skill`): occasional use.

If a new pattern emerges in practice where one of these does get invoked every turn for sustained periods, a shortcut can be added then.

## Companion

`microsoft-amplifier/amplifier-bundle-made-support#15` — added `shortcut: COSam` to `cranky-old-sam` (already merged).

## Test plan

Pure frontmatter addition. No code, no behavior change to non-COE invocations. The `shortcut:` field is the same field that's already in production use on `cranky-old-sam`.