### PR TITLE
docs: broaden crusty-old-engineer to advertise as cross-lifecycle lens

### DIFF
--- a/skills/crusty-old-engineer/SKILL.md
+++ b/skills/crusty-old-engineer/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: crusty-old-engineer
-version: 1.0.0
+version: 1.0.1
 description: |
   Curmudgeonly engineering advisor that provides grounded skepticism, evidence-linked judgment,
   and constructive progress on architectural decisions, legacy refactors, tooling choices, and
   broad "how should I start?" questions. Sounds like a senior systems engineer who has reviewed
   too many designs to be impressed, but still cares about correctness.
-  Use when: architectural decisions, legacy replacements, new tooling evaluation, broad planning questions.
+  A lens for any checkpoint — brainstorm, design, plan, implement, debug, or review — not just up-front decisions.
+  Use when: weighing consequences, hidden costs, or failure modes of any choice — an idea, an architecture,
+  a tooling/legacy call, an implementation path, or a fix — any time the worry is "what will this cost us later?"
 allowed-tools: ["Read", "Grep", "Glob", "Bash", "WebSearch", "WebFetch", "Agent", "AskUserQuestion"]
 user-invocable: true
 shortcut: COE
@@ -23,7 +25,7 @@ Your job is to help people make defensible decisions, not to make them feel good
 
 ## When to Use
 
-Invoke when the user is:
+This is a **lens, not a stage-gate** — hold it up at any checkpoint (brainstorm, design, plan, implement, debug, review) whenever the worry is *"what will this cost us later?"* Invoke when the user is:
 
 - Proposing or evaluating an architectural decision
 - Replacing or refactoring legacy systems


### PR DESCRIPTION
## Summary

Broadens the skill's 'When to Use' framing so it advertises itself as a **cross-lifecycle LENS** usable at any checkpoint (brainstorm, design, plan, implement, debug, review) — not a stage-gated reviewer used only for up-front decisions.

## Changes

- Reworded the frontmatter `description` 'Use when:' line to clarify broader applicability
- Added one-line 'lens, not a stage-gate' intro to the `## When to Use` section
- Bumped skill `version` 1.0.0 → 1.0.1
- No change to the persona's behavior/voice — purely discoverability/scope framing

## Verification

- Single file changed: `skills/crusty-old-engineer/SKILL.md`
- Semantically consistent with sibling skills (cranky-old-sam, restless-old-brian) — all broadened to cross-lifecycle framing