### PR TITLE
feat: add personafy skill for creating advisor-persona archetypes

### DIFF
--- a/skills/personafy/SKILL.md
+++ b/skills/personafy/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: personafy
+description: >
+  Build a new opinionated advisor-persona skill — a reviewer "lens" like
+  crusty-old-engineer — modeled on a real person or archetype and proven from real
+  evidence. Mines the subject's authentic voice and discipline, defines its one
+  distinct load-bearing question, drafts it to the family template, proves it steers
+  in a live session, reduces it, and publishes it to a skills bundle. Use when
+  creating or authoring a persona/advisor skill, adding a sibling to the
+  crusty-old-engineer family, or turning a person's real direction style into a
+  reusable reviewer skill. Also triggers on "personafy" / "personify".
+user-invocable: true
+shortcut: personify
+allowed-tools:
+  - read_file
+  - write_file
+  - edit_file
+  - bash
+  - glob
+  - grep
+  - delegate
+  - load_skill
+  - todo
+model_role: reasoning
+---
+
+# Personafy
+
+Build a new **advisor-persona skill** — an opinionated reviewer "lens" that joins an
+existing family of sibling personas (e.g., `crusty-old-engineer`). The persona is
+modeled on a real person or archetype, grounded in mined evidence, and enforces ONE
+distinct recurring question.
+
+**Success artifact:** a complete, family-conformant `SKILL.md` that is (a) grounded in
+verbatim evidence, (b) *proven to steer* an LLM in a live session, (c) reduced to the
+smallest set that still steers, and (d) loading from its target bundle in a fresh session.
+
+## Inputs
+
+- `<subject>`: (Optional) The person or archetype to model, plus pointers to evidence
+  (session corpora, transcripts, docs). If no corpus exists, derive the persona from a
+  written conceptual brief instead.
+- `<family>`: (Optional) The sibling persona skills to fit alongside. Defaults to the
+  advisor-persona family in `amplifier-bundle-skills` (e.g., `crusty-old-engineer`).
+
+## Steps
+
+### 1. Study the family
+
+Read the existing sibling persona skills' `SKILL.md` in full. Extract: the shared section
+template, the frontmatter/metadata shape, the tone-contract pattern (required / disallowed
+/ style), and — critically — the single **load-bearing question** each sibling owns and how
+they cross-reference each other.
+
+**Success criteria:** You can state each sibling's distinct question in one line and
+reproduce the shared template and metadata shape.
+
+### 2. Observe the siblings in action (optional)
+
+Run one or more existing personas live against a shared, realistic scenario — plus a
+combined "consensus" run — to see how the written instructions translate into actual
+behavior and steering.
+
+- Execution: Delegate to `self` with `context_depth="none"` (one isolated run per persona).
+
+**Success criteria:** You've *seen* how each sibling's instructions become behavior, not
+just read them — enough to know what makes the steering work.
+
+### 3. Define the load-bearing lens
+
+Name the ONE distinct recurring question the new persona enforces. Build a contrast table
+against every sibling.
+
+**Success criteria:** A one-line lens plus a contrast table showing it is genuinely
+distinct from each sibling.
+**Rule:** if the question collapses into a sibling's, it is not a new persona — stop.
+
+### 4. Mine the voice & discipline from real evidence
+
+The heart of the method. Gather the subject's authentic voice and decision-discipline from
+real data (use the conceptual fallback only if no corpus exists).
+
+- **4a. Identify corpora and weight them** — e.g., the subject's own agent-directing
+  sessions (long-term backbone) and human-to-human transcripts (enrichment). Weight recent
+  material so it *informs* but doesn't *overpower* the long-term signal.
+- **4b. Deterministic extraction** — pull ONLY the subject's own words. Exclude delegated
+  sub-sessions (agent-to-agent), and flag/exclude automated eval-harness / smoke-test noise.
+  Build a tracking directory + manifest + batches so the corpus never overflows your context.
+  - Execution: `bash` (jq/grep/sed; never `cat` a huge session file — a single line can
+    exceed your context window).
+- **4c. Fan out scoped analysis agents** — one per batch, each following a shared evidence
+  brief, writing structured findings to disk and returning only a thin summary. Many small
+  agents beat one overloaded agent.
+  - Execution: Delegate (parallel), `model_role="research"`.
+- **4d. Two-tier synthesis** — partial synthesizers consolidate groups of findings, then a
+  final synthesizer produces ONE profile: recurring traits ranked by cross-source
+  corroboration, verbatim catchphrases, pet peeves, decision lenses, and the top
+  "this is them" quotes. Quarantine AI-authored vocabulary (don't attribute it to the
+  subject). Record confidence and which batches were synthetic.
+  - Execution: Delegate, `model_role="reasoning"`.
+
+**Conceptual fallback (no corpus):** derive the same profile fields from a written brief
+about the archetype; mark everything as designed-not-mined.
+
+**Success criteria:** A consolidated profile where every load-bearing trait is backed by a
+verbatim quote (or explicitly marked as designed), ranked by corroboration, with synthetic
+noise excluded.
+**Rule:** ground every claim in real evidence; an honest "N/A — not observed" beats a
+fabricated trait.
+**Artifacts:** the profile file path.
+
+### 5. Draft the SKILL.md to the family template
+
+Write the skill mirroring the siblings exactly: identity (defined by negation — "not X, not
+Y"), When-to-Use framed as a **cross-stage lens, not a stage-gate**, the tone contract
+(required / disallowed / style), Core Behaviors each anchored in a **verbatim quote** from
+the profile, an Output Structure, one worked Example, Explicit Non-Goals, a
+Relationship-to-siblings section, and a Final Note. Match the family's frontmatter format.
+
+**Success criteria:** A complete draft, structurally identical to the siblings, every
+behavior grounded in the profile.
+**Rule:** keep the verbatim quotes — they are the highest-signal tokens and the soul of the
+persona.
+
+### 6. Prove it steers in a live session
+
+Run the draft in a fresh CLI session against a real-ish scenario and confirm it adopts the
+voice and hits each behavior.
+
+```bash
+amplifier run --mode single --output-format text \
+  "Load the skill \"<name>\" and review the following as that persona: <realistic scenario>"
+```
+
+**Success criteria:** A transcript showing the persona *behaving* as designed (voice + each
+behavior firing).
+**Rule:** proof is demonstrated behavior — "the file exists" is NOT proof.
+
+### 7. Reduce & refine
+
+Apply context-reduction: cut redundancy to the smallest set that still steers (drop restated
+procedure, compress prose), but keep the verbatim quotes and the structural skeleton.
+Re-prove (Step 6) if the cut was heavy.
+
+**Success criteria:** A leaner SKILL.md with the same steering power, verified.
+
+### 8. Name it and choose its home
+
+Pick a name in the family's convention. A **shareable archetype** name (a generic role) →
+a public bundle; a name that **references a real person** → a private/team bundle.
+
+- Execution: Delegate to design/voice agents for name options (optional).
+- **Human checkpoint:** the user chooses the final name and target bundle.
+
+**Success criteria:** Name chosen and target bundle decided — public vs private matched to
+whether the name exposes a real person.
+
+### 9. Publish to the target bundle
+
+Place `SKILL.md` at `<bundle>/skills/<name>/SKILL.md`. Verify the bundle exposes skills via
+the **canonical directory-discovery** registration — its `tool-skills` config points
+`config.skills` at the whole `skills/` directory (`#subdirectory=skills`), so a new skill
+dir is auto-discovered. Do NOT rely on per-skill wrapper behaviors. Then run the git
+lifecycle.
+
+- Execution: Delegate the branch/commit/PR/merge to `foundation:git-ops`.
+- **Human checkpoint:** confirm before opening/merging the PR.
+
+**Success criteria:** PR merged into the target bundle.
+**Rule:** a `SKILL.md` in `skills/` is NOT exposed unless the bundle points `tool-skills`
+at the `skills/` directory — registration is directory-based, not per-file.
+
+### 10. Prove it loads from the bundle
+
+Run `amplifier update`, then load the skill in a FRESH session and confirm `loaded_from` is
+the bundle cache — not a local `~/.amplifier/skills` copy.
+
+**Success criteria:** `load_skill` resolves the skill from the bundle cache path in a clean
+session.
+**Rule:** "merged on main" ≠ "loads for a user" — verify discoverability end-to-end, the
+same gate the persona itself would demand.


### PR DESCRIPTION
## Summary

Adds the new 'personafy' skill (canonical `/personafy`, with 'personify' shortcut alias for the common typo). 

personafy is a meta-authoring skill that captures the repeatable process for creating opinionated advisor-persona skills — a reviewer 'lens' like crusty-old-engineer. It is the sibling of the existing 'skillify' skill, specialized for advisor personas.

## What the skill encodes

The skill documents the complete workflow:

1. Study the family → 
2. (optional) Observe siblings live → 
3. Define the load-bearing lens → 
4. Mine voice & discipline from real evidence (deterministic extraction, fan-out analysis agents, two-tier synthesis, weighting, quarantine AI vocab) → 
5. Draft to the family template → 
6. **Prove it steers live** → 
7. Reduce → 
8. Name & home (public archetype vs private person-named) → 
9. Publish via **canonical directory-discovery** → 
10. **Prove it loads from the bundle**

The skill bakes in two hard lessons as explicit **Rules**: proof = demonstrated behavior (not file-present), and registration is directory-based (not per-file).

## Verification

The skill has been verified locally: the real `discover_skills()` loader parsed it cleanly with:
- `name=personafy`
- `shortcut=personify` (alias registers successfully)
- `user_invocable=true`
- No validation warnings

## Testing

Both `/personafy` and `/personify` will be available to end users via the directory-discovery pattern once merged.