### PR TITLE
feat(tool-skills): fork-skill parameter passing — $ARGUMENTS delivery (fixes council) + optional context inheritance

### DIFF
--- a/modules/tool-skills/amplifier_module_tool_skills/__init__.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/__init__.py
@@ -18,6 +18,7 @@ try:
 except ImportError:  # foundation not installed in all deployment configs
     RUNTIME_SKILL_OVERLAY_CAPABILITY = "runtime_skill_overlay"  # type: ignore[assignment]
 
+from amplifier_module_tool_skills import context_inheritance as ctx_inherit
 from amplifier_module_tool_skills.discovery import SkillMetadata
 from amplifier_module_tool_skills.discovery import discover_skills
 from amplifier_module_tool_skills.discovery import discover_skills_multi_source
@@ -497,6 +498,37 @@ Skill Discovery:
                     "type": "string",
                     "description": "Register a new skill source. Accepts @namespace:path, git+https:// URLs, or local paths.",
                 },
+                "context_depth": {
+                    "type": "string",
+                    "enum": ["none", "recent", "all"],
+                    "description": (
+                        "FORK SKILLS ONLY. Controls HOW MUCH of the parent conversation "
+                        "the forked sub-session inherits. 'none' (DEFAULT) = clean slate, "
+                        "the sub-session sees only the skill body; 'recent' = the last N "
+                        "turns (N set by context_turns); 'all' = the full parent history. "
+                        "Ignored for non-fork (inline) skills, which already run in the "
+                        "current context. Default 'none' preserves the historical fork "
+                        "behavior, so omit it unless the forked skill genuinely needs "
+                        "parent context."
+                    ),
+                },
+                "context_turns": {
+                    "type": "integer",
+                    "description": (
+                        "FORK SKILLS ONLY. Number of recent turns to inherit when "
+                        "context_depth='recent' (default: 5). Ignored otherwise."
+                    ),
+                },
+                "context_scope": {
+                    "type": "string",
+                    "enum": ["conversation", "agents", "full"],
+                    "description": (
+                        "FORK SKILLS ONLY. Controls WHICH parent content is inherited when "
+                        "context_depth is not 'none'. 'conversation' (DEFAULT) = user/"
+                        "assistant text only; 'agents' = + delegate/task agent results; "
+                        "'full' = + all tool results (truncated). Ignored for non-fork skills."
+                    ),
+                },
             },
         }
 
@@ -603,7 +635,18 @@ Skill Discovery:
                 },
             )
 
-        return await self._load_skill(skill_name)
+        # Parent-context inheritance (fork skills only). Defaults to a clean
+        # slate ("none") so non-fork skills and unaware callers are unaffected.
+        context_depth = input.get("context_depth", ctx_inherit.DEFAULT_DEPTH)
+        context_scope = input.get("context_scope", ctx_inherit.DEFAULT_SCOPE)
+        context_turns = input.get("context_turns", ctx_inherit.DEFAULT_TURNS)
+
+        return await self._load_skill(
+            skill_name,
+            context_depth=context_depth,
+            context_scope=context_scope,
+            context_turns=context_turns,
+        )
 
     def get_effective_skills(self) -> dict[str, SkillMetadata]:
         """Return the merged static + runtime-overlay skill catalog.
@@ -750,12 +793,22 @@ Skill Discovery:
 
         return ToolResult(success=True, output=info)
 
-    async def _load_skill(self, skill_name: str) -> ToolResult:
+    async def _load_skill(
+        self,
+        skill_name: str,
+        context_depth: str = ctx_inherit.DEFAULT_DEPTH,
+        context_scope: str = ctx_inherit.DEFAULT_SCOPE,
+        context_turns: int = ctx_inherit.DEFAULT_TURNS,
+    ) -> ToolResult:
         """Load full skill content.
 
         Consults both local and runtime-overlay skills via
         get_effective_skills(); contributed skills from active modes
         are loadable here.
+
+        The context_* parameters only take effect for fork skills (see
+        _execute_fork); inline skills ignore them because they already load
+        into the parent's live context.
         """
         effective_skills = self.get_effective_skills()
         if skill_name not in effective_skills:
@@ -825,7 +878,14 @@ Skill Discovery:
         if metadata.context == "fork" and self.coordinator:
             spawn_fn = self.coordinator.get_capability("session.spawn")
             if spawn_fn is not None:
-                return await self._execute_fork(skill_name, metadata, body)
+                return await self._execute_fork(
+                    skill_name,
+                    metadata,
+                    body,
+                    context_depth=context_depth,
+                    context_scope=context_scope,
+                    context_turns=context_turns,
+                )
             else:
                 logger.warning(
                     f"Fork skill '{skill_name}' loaded inline (session.spawn not available)"
@@ -843,11 +903,34 @@ Skill Discovery:
             },
         )
 
+    async def _get_parent_messages(self) -> list[dict[str, Any]] | None:
+        """Fetch the parent session's full message history, or None if unavailable.
+
+        Mirrors the delegate tool: reads the mounted context manager and returns
+        its messages. Returns None (no inheritance) when context is unavailable
+        or errors — a legitimate "clean slate" state, not a masked failure.
+        """
+        if not self.coordinator:
+            return None
+        parent_context = self.coordinator.get("context")
+        if not parent_context or not hasattr(parent_context, "get_messages"):
+            logger.debug("No parent context available for fork inheritance")
+            return None
+        try:
+            messages = await parent_context.get_messages()
+            return messages if messages else None
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"Failed to get parent messages for fork: {e}")
+            return None
+
     async def _execute_fork(
         self,
         skill_name: str,
         metadata: Any,
         body: str,
+        context_depth: str = ctx_inherit.DEFAULT_DEPTH,
+        context_scope: str = ctx_inherit.DEFAULT_SCOPE,
+        context_turns: int = ctx_inherit.DEFAULT_TURNS,
     ) -> ToolResult:
         """Execute a fork skill by delegating to a sub-session via spawn.
 
@@ -855,6 +938,12 @@ Skill Discovery:
             skill_name: Name of the skill being executed.
             metadata: Skill metadata containing model/agent configuration.
             body: Raw (unpreprocessed) skill body content.
+            context_depth: Parent-context inheritance amount ("none" | "recent" |
+                "all"). Defaults to "none" (clean slate — the historical fork
+                behavior).
+            context_scope: Which parent content to inherit ("conversation" |
+                "agents" | "full"). Only used when context_depth != "none".
+            context_turns: Number of recent turns when context_depth == "recent".
 
         Returns:
             ToolResult containing the delegate response, or an error ToolResult
@@ -870,6 +959,21 @@ Skill Discovery:
             processed_body = await preprocess(
                 body, skill_dir=metadata.path.parent, arguments=None, trusted=is_trusted
             )
+
+            # 1b. Optionally inherit parent-conversation context. By default
+            # (context_depth == "none") a fork starts with a clean slate. When a
+            # caller opts in, we select+sanitize parent messages exactly like the
+            # delegate tool and prepend them to the body as a text preamble, so
+            # the sub-session sees them in its first user turn.
+            instruction = processed_body
+            if context_depth != "none":
+                parent_messages = await self._get_parent_messages()
+                inherited = ctx_inherit.build_inherited_context(
+                    parent_messages, context_depth, context_turns, context_scope
+                )
+                if inherited:
+                    context_block = ctx_inherit.format_parent_context(inherited)
+                    instruction = f"{context_block}\n\n[YOUR TASK]\n{processed_body}"
 
             # 2. Resolve model selection via resolve_skill_model() using metadata fields
             model_resolution = resolve_skill_model(
@@ -935,7 +1039,7 @@ Skill Discovery:
             # infinite recursion. No orchestrator_config marker needed.
             result = await spawn_fn(
                 agent_name="self",
-                instruction=processed_body,
+                instruction=instruction,
                 parent_session=parent_session,
                 agent_configs=agent_configs,
                 sub_session_id=sub_session_id,

--- a/modules/tool-skills/amplifier_module_tool_skills/__init__.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/__init__.py
@@ -498,6 +498,18 @@ Skill Discovery:
                     "type": "string",
                     "description": "Register a new skill source. Accepts @namespace:path, git+https:// URLs, or local paths.",
                 },
+                "arguments": {
+                    "type": "string",
+                    "description": (
+                        "User argument string for the skill, substituted into the "
+                        "skill body wherever it uses $ARGUMENTS (and positional $0, $1, ...). "
+                        "This is how a /command invocation's text (e.g. the target in "
+                        "`/council <target>`) reaches the skill. REQUIRED to pass through for "
+                        "fork skills: a forked sub-session cannot see the parent conversation, "
+                        "so without this its $ARGUMENTS is empty. When the user supplies "
+                        "argument text for a skill, always forward it here."
+                    ),
+                },
                 "context_depth": {
                     "type": "string",
                     "enum": ["none", "recent", "all"],
@@ -635,6 +647,12 @@ Skill Discovery:
                 },
             )
 
+        # User arguments for $ARGUMENTS / positional substitution. Critical for
+        # fork skills: a fork sub-session cannot see the parent conversation, so
+        # this is the only channel through which a /command's argument text
+        # (e.g. the target in `/council <target>`) reaches the forked body.
+        arguments = input.get("arguments") or None
+
         # Parent-context inheritance (fork skills only). Defaults to a clean
         # slate ("none") so non-fork skills and unaware callers are unaffected.
         context_depth = input.get("context_depth", ctx_inherit.DEFAULT_DEPTH)
@@ -643,6 +661,7 @@ Skill Discovery:
 
         return await self._load_skill(
             skill_name,
+            arguments=arguments,
             context_depth=context_depth,
             context_scope=context_scope,
             context_turns=context_turns,
@@ -796,6 +815,7 @@ Skill Discovery:
     async def _load_skill(
         self,
         skill_name: str,
+        arguments: str | None = None,
         context_depth: str = ctx_inherit.DEFAULT_DEPTH,
         context_scope: str = ctx_inherit.DEFAULT_SCOPE,
         context_turns: int = ctx_inherit.DEFAULT_TURNS,
@@ -805,6 +825,11 @@ Skill Discovery:
         Consults both local and runtime-overlay skills via
         get_effective_skills(); contributed skills from active modes
         are loadable here.
+
+        ``arguments`` is the user's argument string ($ARGUMENTS / positional
+        substitution). It is applied for both inline and fork skills. For fork
+        skills it is the ONLY channel by which a /command's argument text reaches
+        the forked body, since the fork cannot see the parent conversation.
 
         The context_* parameters only take effect for fork skills (see
         _execute_fork); inline skills ignore them because they already load
@@ -833,7 +858,7 @@ Skill Discovery:
             body = await preprocess(
                 body,
                 skill_dir=metadata.path.parent,
-                arguments=None,
+                arguments=arguments,
                 execute_shell=False,
             )
 
@@ -882,6 +907,7 @@ Skill Discovery:
                     skill_name,
                     metadata,
                     body,
+                    arguments=arguments,
                     context_depth=context_depth,
                     context_scope=context_scope,
                     context_turns=context_turns,
@@ -928,6 +954,7 @@ Skill Discovery:
         skill_name: str,
         metadata: Any,
         body: str,
+        arguments: str | None = None,
         context_depth: str = ctx_inherit.DEFAULT_DEPTH,
         context_scope: str = ctx_inherit.DEFAULT_SCOPE,
         context_turns: int = ctx_inherit.DEFAULT_TURNS,
@@ -938,6 +965,10 @@ Skill Discovery:
             skill_name: Name of the skill being executed.
             metadata: Skill metadata containing model/agent configuration.
             body: Raw (unpreprocessed) skill body content.
+            arguments: User argument string substituted into the body's
+                $ARGUMENTS / positional placeholders. This is the ONLY channel by
+                which a /command's argument text reaches the fork, since the fork
+                cannot see the parent conversation.
             context_depth: Parent-context inheritance amount ("none" | "recent" |
                 "all"). Defaults to "none" (clean slate — the historical fork
                 behavior).
@@ -953,11 +984,17 @@ Skill Discovery:
             # _execute_fork() is only called when coordinator is confirmed non-None
             assert self.coordinator is not None
 
-            # 1. Preprocess body with skill_dir and arguments
-            # Remote-source skills are untrusted — block shell execution
+            # 1. Preprocess body with skill_dir and arguments. Passing
+            # `arguments` here is what makes $ARGUMENTS (and positional $0/$1...)
+            # resolve inside the fork — the fork cannot see the parent
+            # conversation, so this is its only line to the user's intent.
+            # Remote-source skills are untrusted — block shell execution.
             is_trusted = not is_remote_source(metadata.source)
             processed_body = await preprocess(
-                body, skill_dir=metadata.path.parent, arguments=None, trusted=is_trusted
+                body,
+                skill_dir=metadata.path.parent,
+                arguments=arguments,
+                trusted=is_trusted,
             )
 
             # 1b. Optionally inherit parent-conversation context. By default

--- a/modules/tool-skills/amplifier_module_tool_skills/context_inheritance.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/context_inheritance.py
@@ -1,0 +1,232 @@
+"""Parent-conversation context inheritance for fork skills.
+
+A fork skill spawns a fresh sub-session with no conversation history. By
+default that is exactly what we want (a clean slate). But a caller can opt
+into inheriting some of the parent conversation, using the same two-axis
+model the ``delegate`` tool exposes:
+
+    context_depth  -> HOW MUCH:  "none" | "recent" | "all"
+    context_scope  -> WHICH:     "conversation" | "agents" | "full"
+
+The transforms below are intentionally a faithful mirror of the logic in
+``amplifier_module_tool_delegate`` so that a fork skill and a delegate call
+inherit context identically. They are kept as pure functions (no coordinator
+state) so they are trivial to test and so this module stays a self-contained
+brick with no dependency on the delegate package.
+
+The selected/sanitized messages are rendered to a text block and prepended to
+the skill body before it is handed to the spawned sub-session as its first
+user turn. This matches how ``delegate`` injects parent context: as a text
+preamble, not as replayed conversation turns.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Valid values, exposed so the tool schema and validation share one source.
+VALID_DEPTHS = ("none", "recent", "all")
+VALID_SCOPES = ("conversation", "agents", "full")
+
+DEFAULT_DEPTH = "none"
+DEFAULT_SCOPE = "conversation"
+DEFAULT_TURNS = 5
+
+# Content block types that are never human-readable conversation text.
+_FILTERED_BLOCK_TYPES = {
+    "tool_use",
+    "tool_call",
+    "tool_result",
+    "thinking",
+    "redacted_thinking",
+}
+
+
+def extract_recent_turns(
+    messages: list[dict[str, Any]], n_turns: int
+) -> list[dict[str, Any]]:
+    """Return the last ``n_turns`` user->assistant turns.
+
+    A "turn" starts at a user message and runs until the next user message.
+    """
+    if not messages or n_turns <= 0:
+        return []
+
+    turn_starts = [i for i, m in enumerate(messages) if m.get("role") == "user"]
+    if not turn_starts:
+        return messages  # No user turns; nothing to slice on.
+    if len(turn_starts) <= n_turns:
+        return messages  # Fewer turns than requested; return all.
+
+    start_index = turn_starts[-n_turns]
+    return messages[start_index:]
+
+
+def sanitize_content(content: Any) -> str:
+    """Extract human-readable text from a message ``content`` field.
+
+    Handles both the plain-string and list-of-blocks shapes; drops tool and
+    reasoning blocks.
+    """
+    if isinstance(content, str):
+        return content
+
+    if isinstance(content, list):
+        text_parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                block_type = block.get("type", "")
+                if block_type == "text":
+                    text = block.get("text", "")
+                    if text:
+                        text_parts.append(text)
+                elif block_type not in _FILTERED_BLOCK_TYPES:
+                    logger.debug("Unknown content block type '%s'", block_type)
+            elif isinstance(block, str):
+                text_parts.append(block)
+        if text_parts:
+            return "\n".join(text_parts)
+
+    return ""
+
+
+def _sanitize_conversation_only(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Keep only user/assistant conversation text; strip all tool content."""
+    sanitized: list[dict[str, Any]] = []
+    for msg in messages:
+        role = msg.get("role")
+        if role == "tool" or msg.get("tool_call_id"):
+            continue
+        if role in ("user", "assistant"):
+            if role == "assistant" and msg.get("tool_calls") and not msg.get("content"):
+                continue
+            text = sanitize_content(msg.get("content", ""))
+            if text:
+                sanitized.append({"role": role, "content": text})
+    return sanitized
+
+
+def _sanitize_with_agent_results(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Conversation text plus results from agent tools (delegate/task)."""
+    sanitized: list[dict[str, Any]] = []
+    agent_tools = {"delegate", "task"}
+    for msg in messages:
+        role = msg.get("role")
+        if role == "tool":
+            tool_name = msg.get("name", "")
+            if tool_name in agent_tools:
+                content = msg.get("content", "")
+                if content:
+                    sanitized.append(
+                        {
+                            "role": "assistant",
+                            "content": f"[Agent Result from {tool_name}]: {content}",
+                        }
+                    )
+            continue
+        if msg.get("tool_call_id"):
+            # OpenAI-shaped tool result; tool name not recoverable here.
+            continue
+        if role in ("user", "assistant"):
+            if role == "assistant" and msg.get("tool_calls") and not msg.get("content"):
+                continue
+            text = sanitize_content(msg.get("content", ""))
+            if text:
+                sanitized.append({"role": role, "content": text})
+    return sanitized
+
+
+def _sanitize_all_content(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Conversation text plus all tool results (truncated)."""
+    sanitized: list[dict[str, Any]] = []
+    for msg in messages:
+        role = msg.get("role")
+        if role == "tool":
+            tool_name = msg.get("name", "unknown")
+            content = msg.get("content", "")
+            if content:
+                if len(content) > 4000:
+                    content = content[:4000] + "... [truncated]"
+                sanitized.append(
+                    {
+                        "role": "assistant",
+                        "content": f"[Tool Result from {tool_name}]: {content}",
+                    }
+                )
+            continue
+        if msg.get("tool_call_id"):
+            continue
+        if role in ("user", "assistant"):
+            if role == "assistant" and msg.get("tool_calls") and not msg.get("content"):
+                continue
+            text = sanitize_content(msg.get("content", ""))
+            if text:
+                sanitized.append({"role": role, "content": text})
+    return sanitized
+
+
+def build_inherited_context(
+    messages: list[dict[str, Any]] | None,
+    depth: str,
+    turns: int,
+    scope: str,
+) -> list[dict[str, Any]] | None:
+    """Select and sanitize parent ``messages`` by depth (how much) and scope (which).
+
+    ``messages`` is the raw parent history (already fetched by the caller).
+    Returns the sanitized messages, or ``None`` when nothing should be
+    inherited (depth "none", or no parent messages available).
+    """
+    if depth == "none":
+        return None
+    if not messages:
+        return None
+
+    # Step 1: depth filter.
+    if depth == "recent":
+        messages = extract_recent_turns(messages, turns)
+    # "all" -> unchanged.
+
+    # Step 2: scope filter.
+    if scope == "conversation":
+        return _sanitize_conversation_only(messages)
+    if scope == "agents":
+        return _sanitize_with_agent_results(messages)
+    return _sanitize_all_content(messages)
+
+
+def format_parent_context(messages: list[dict[str, Any]]) -> str:
+    """Render sanitized parent messages as a text block to prepend to a skill body."""
+    if not messages:
+        return ""
+
+    lines = [
+        "[PARENT CONVERSATION CONTEXT]",
+        "The following is conversation history inherited from the parent session:",
+        "",
+    ]
+    for msg in messages:
+        role = msg.get("role", "unknown")
+        content = msg.get("content", "")
+        role_label = (
+            "USER"
+            if role == "user"
+            else "ASSISTANT"
+            if role == "assistant"
+            else role.upper()
+        )
+        if len(content) > 2000:
+            content = content[:2000] + "... [truncated]"
+        lines.append(f"{role_label}: {content}")
+        lines.append("")
+    lines.append("[END PARENT CONTEXT]")
+    return "\n".join(lines)

--- a/modules/tool-skills/tests/test_fork_arguments.py
+++ b/modules/tool-skills/tests/test_fork_arguments.py
@@ -1,0 +1,114 @@
+"""Tests for fork-skill $ARGUMENTS delivery.
+
+Locks down the fix for the council bug: a fork skill's sub-session cannot see
+the parent conversation, so a /command's argument text must be threaded through
+the load_skill tool -> _load_skill -> _execute_fork -> preprocess(arguments=...)
+and substituted into the body's $ARGUMENTS. Before the fix, _execute_fork
+hardcoded arguments=None, so $ARGUMENTS was always "" inside the fork and
+council's "empty -> stop" guard fired on every invocation.
+
+These tests run the REAL preprocess (not mocked), so they prove actual
+$ARGUMENTS substitution end-to-end inside _execute_fork.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from amplifier_module_tool_skills import SkillsTool
+from amplifier_module_tool_skills.discovery import SkillMetadata
+
+
+def _make_skill(tmp_path: Path, *, body: str, context: str) -> SkillMetadata:
+    skill_dir = tmp_path / "arg-skill"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_path = skill_dir / "SKILL.md"
+    # Frontmatter + body; extract_skill_body reads the body after frontmatter.
+    skill_path.write_text(
+        f"---\nname: arg-skill\ndescription: test\ncontext: {context}\n---\n\n{body}\n",
+        encoding="utf-8",
+    )
+    return SkillMetadata(
+        name="arg-skill",
+        description="arg skill under test",
+        path=skill_path,
+        source=str(tmp_path),
+        context=context,
+    )
+
+
+def _spawn_fn() -> AsyncMock:
+    return AsyncMock(
+        return_value={
+            "output": "child-output",
+            "session_id": "child-1",
+            "status": "success",
+            "turn_count": 1,
+            "metadata": {},
+        }
+    )
+
+
+def _coordinator(spawn: AsyncMock) -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.session = MagicMock()
+    coordinator.config = {"agents": {}}
+    coordinator.hooks = MagicMock()
+    coordinator.hooks.emit = AsyncMock()
+    coordinator.get = MagicMock(return_value=None)
+    capabilities = {"model_role_resolver": None, "session.spawn": spawn}
+    coordinator.get_capability = MagicMock(side_effect=capabilities.get)
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_fork_substitutes_arguments_into_body(tmp_path):
+    """$ARGUMENTS in a fork body resolves to the passed argument string."""
+    spawn = _spawn_fn()
+    coordinator = _coordinator(spawn)
+    tool = SkillsTool(config={}, coordinator=coordinator, resolved_dirs=[])
+    metadata = _make_skill(
+        tmp_path, body="Review the target: $ARGUMENTS", context="fork"
+    )
+
+    await tool._execute_fork(
+        "arg-skill", metadata, "Review the target: $ARGUMENTS", arguments="src/app.py"
+    )
+
+    instruction = spawn.await_args.kwargs["instruction"]
+    assert "Review the target: src/app.py" in instruction
+    assert "$ARGUMENTS" not in instruction
+
+
+@pytest.mark.asyncio
+async def test_fork_empty_arguments_yields_empty_substitution(tmp_path):
+    """No arguments -> $ARGUMENTS becomes empty (historical behavior preserved)."""
+    spawn = _spawn_fn()
+    coordinator = _coordinator(spawn)
+    tool = SkillsTool(config={}, coordinator=coordinator, resolved_dirs=[])
+    metadata = _make_skill(tmp_path, body="Target=[$ARGUMENTS]", context="fork")
+
+    await tool._execute_fork("arg-skill", metadata, "Target=[$ARGUMENTS]")
+
+    instruction = spawn.await_args.kwargs["instruction"]
+    assert "Target=[]" in instruction
+
+
+@pytest.mark.asyncio
+async def test_load_skill_threads_arguments_to_fork(tmp_path):
+    """execute(arguments=...) reaches the fork body via _load_skill -> _execute_fork."""
+    spawn = _spawn_fn()
+    coordinator = _coordinator(spawn)
+    tool = SkillsTool(config={}, coordinator=coordinator, resolved_dirs=[])
+    metadata = _make_skill(tmp_path, body="Do $ARGUMENTS", context="fork")
+    # Register the skill so execute() can find it by name.
+    tool.skills["arg-skill"] = metadata
+
+    result = await tool.execute({"skill_name": "arg-skill", "arguments": "the thing"})
+
+    assert result.success
+    instruction = spawn.await_args.kwargs["instruction"]
+    assert "Do the thing" in instruction

--- a/modules/tool-skills/tests/test_fork_context_inheritance.py
+++ b/modules/tool-skills/tests/test_fork_context_inheritance.py
@@ -1,0 +1,221 @@
+"""Tests for fork-skill parent-conversation context inheritance.
+
+Locks down the feature that lets a caller opt a fork skill into inheriting
+parent-conversation context using the same two-axis model as the delegate
+tool (context_depth + context_scope), while defaulting to a clean slate
+("none") so existing fork skills are unaffected.
+
+Two layers are proven here:
+  1. The pure transforms in context_inheritance (depth/scope filtering, format).
+  2. The wiring in SkillsTool._execute_fork — that the selected context is
+     actually prepended to the instruction handed to spawn_fn, and that the
+     default ("none") changes nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from amplifier_module_tool_skills import SkillsTool
+from amplifier_module_tool_skills import context_inheritance as ci
+from amplifier_module_tool_skills.discovery import SkillMetadata
+
+# --- Sample parent history shared across transform tests -------------------
+
+PARENT_MESSAGES = [
+    {"role": "user", "content": "first question"},
+    {
+        "role": "assistant",
+        "content": [
+            {"type": "thinking", "thinking": "internal reasoning"},
+            {"type": "text", "text": "first answer"},
+        ],
+    },
+    {"role": "user", "content": "second question"},
+    {"role": "assistant", "content": "", "tool_calls": [{"id": "1"}]},
+    {"role": "tool", "name": "delegate", "content": "agent findings"},
+    {"role": "tool", "name": "bash", "content": "raw bash output"},
+    {"role": "assistant", "content": "second answer"},
+    {"role": "user", "content": "third question"},
+]
+
+
+# --- Layer 1: pure transforms ----------------------------------------------
+
+
+def test_depth_none_returns_clean_slate():
+    assert ci.build_inherited_context(PARENT_MESSAGES, "none", 5, "conversation") is None
+
+
+def test_no_messages_returns_none():
+    assert ci.build_inherited_context(None, "all", 5, "conversation") is None
+    assert ci.build_inherited_context([], "all", 5, "conversation") is None
+
+
+def test_scope_conversation_strips_tool_and_thinking():
+    out = ci.build_inherited_context(PARENT_MESSAGES, "all", 5, "conversation")
+    joined = " ".join(m["content"] for m in out)
+    assert "first answer" in joined
+    assert "internal reasoning" not in joined  # thinking stripped
+    assert "agent findings" not in joined  # tool result stripped
+    assert "raw bash output" not in joined
+    # The pure tool-call assistant turn produced no text -> dropped.
+    assert [m["role"] for m in out] == [
+        "user",
+        "assistant",
+        "user",
+        "assistant",
+        "user",
+    ]
+
+
+def test_scope_agents_includes_delegate_but_not_bash():
+    out = ci.build_inherited_context(PARENT_MESSAGES, "all", 5, "agents")
+    joined = " ".join(m["content"] for m in out)
+    assert "agent findings" in joined
+    assert "raw bash output" not in joined
+
+
+def test_scope_full_includes_all_tool_results():
+    out = ci.build_inherited_context(PARENT_MESSAGES, "all", 5, "full")
+    joined = " ".join(m["content"] for m in out)
+    assert "agent findings" in joined
+    assert "raw bash output" in joined
+
+
+def test_depth_recent_limits_to_last_turn():
+    out = ci.build_inherited_context(PARENT_MESSAGES, "recent", 1, "conversation")
+    assert out == [{"role": "user", "content": "third question"}]
+
+
+def test_format_block_has_markers():
+    out = ci.build_inherited_context(PARENT_MESSAGES, "recent", 1, "conversation")
+    block = ci.format_parent_context(out)
+    assert block.startswith("[PARENT CONVERSATION CONTEXT]")
+    assert block.rstrip().endswith("[END PARENT CONTEXT]")
+    assert "USER: third question" in block
+
+
+# --- Layer 2: wiring in _execute_fork --------------------------------------
+
+
+def _make_fork_metadata(tmp_path: Path) -> SkillMetadata:
+    skill_dir = tmp_path / "fork-skill"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_path = skill_dir / "SKILL.md"
+    skill_path.write_text("# stub\n", encoding="utf-8")
+    return SkillMetadata(
+        name="fork-skill",
+        description="Fork skill under test",
+        path=skill_path,
+        source=str(tmp_path),
+        context="fork",
+    )
+
+
+def _make_coordinator(spawn_fn: AsyncMock, parent_messages=None) -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.session = MagicMock()
+    coordinator.config = {"agents": {}}
+    coordinator.hooks = MagicMock()
+    coordinator.hooks.emit = AsyncMock()
+
+    # _get_parent_messages() calls coordinator.get("context").get_messages()
+    if parent_messages is not None:
+        context_mgr = MagicMock()
+        context_mgr.get_messages = AsyncMock(return_value=parent_messages)
+    else:
+        context_mgr = None
+    coordinator.get = MagicMock(return_value=context_mgr)
+
+    capabilities = {
+        "model_role_resolver": None,
+        "session.spawn": spawn_fn,
+    }
+    coordinator.get_capability = MagicMock(side_effect=capabilities.get)
+    return coordinator
+
+
+def _spawn_fn() -> AsyncMock:
+    return AsyncMock(
+        return_value={
+            "output": "child-output",
+            "session_id": "child-1",
+            "status": "success",
+            "turn_count": 1,
+            "metadata": {},
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_none_does_not_inject_context(tmp_path):
+    """Default fork behavior: instruction == processed body, no context block."""
+    spawn = _spawn_fn()
+    coordinator = _make_coordinator(spawn, parent_messages=PARENT_MESSAGES)
+    tool = SkillsTool(config={}, coordinator=coordinator, resolved_dirs=[])
+    metadata = _make_fork_metadata(tmp_path)
+
+    with patch(
+        "amplifier_module_tool_skills.preprocess",
+        new=AsyncMock(return_value="PROCESSED BODY"),
+    ):
+        await tool._execute_fork("fork-skill", metadata, "raw body")
+
+    instruction = spawn.await_args.kwargs["instruction"]
+    assert instruction == "PROCESSED BODY"
+    assert "PARENT CONVERSATION CONTEXT" not in instruction
+
+
+@pytest.mark.asyncio
+async def test_depth_all_prepends_parent_context(tmp_path):
+    """Opting in: parent context block is prepended before the task body."""
+    spawn = _spawn_fn()
+    coordinator = _make_coordinator(spawn, parent_messages=PARENT_MESSAGES)
+    tool = SkillsTool(config={}, coordinator=coordinator, resolved_dirs=[])
+    metadata = _make_fork_metadata(tmp_path)
+
+    with patch(
+        "amplifier_module_tool_skills.preprocess",
+        new=AsyncMock(return_value="PROCESSED BODY"),
+    ):
+        await tool._execute_fork(
+            "fork-skill",
+            metadata,
+            "raw body",
+            context_depth="all",
+            context_scope="conversation",
+        )
+
+    instruction = spawn.await_args.kwargs["instruction"]
+    assert "[PARENT CONVERSATION CONTEXT]" in instruction
+    assert "[YOUR TASK]" in instruction
+    assert instruction.endswith("PROCESSED BODY")
+    assert "first answer" in instruction
+    # Context precedes the task.
+    assert instruction.index("PARENT CONVERSATION CONTEXT") < instruction.index(
+        "[YOUR TASK]"
+    )
+
+
+@pytest.mark.asyncio
+async def test_optin_but_no_parent_context_is_clean(tmp_path):
+    """Opting in with no available parent context falls back to a clean body."""
+    spawn = _spawn_fn()
+    coordinator = _make_coordinator(spawn, parent_messages=None)
+    tool = SkillsTool(config={}, coordinator=coordinator, resolved_dirs=[])
+    metadata = _make_fork_metadata(tmp_path)
+
+    with patch(
+        "amplifier_module_tool_skills.preprocess",
+        new=AsyncMock(return_value="PROCESSED BODY"),
+    ):
+        await tool._execute_fork(
+            "fork-skill", metadata, "raw body", context_depth="all"
+        )
+
+    instruction = spawn.await_args.kwargs["instruction"]
+    assert instruction == "PROCESSED BODY"


### PR DESCRIPTION
## Summary

Delivers two related improvements to fork-skill invocation:

1. **$ARGUMENTS delivery (fixes council)** — fork skills now receive the `$ARGUMENTS` variable populated with user input from slash commands, enabling council and other fork-based skills to process their targets.
2. **Optional parent-conversation context inheritance** — fork skills can now optionally inherit parent-session context (recent turns, delegate/task results, etc.) via caller-side `context_depth` and `context_scope` knobs, defaulting to `none` for zero impact on existing skills.

## The Problem (Commit 8380be4)

Fork skills never received `$ARGUMENTS`, causing council to always print its usage block regardless of input.

When a user invokes `/council review this idea`, the CLI dispatcher forwards the skill name and arguments to the model. The model calls `load_skill` via the tool. But the synthetic prompt injected by app-cli never instructed the model to pass the `arguments` parameter, so fork skills received `arguments=None`, which became an empty string in preprocessing. Council's guard fires on empty `$ARGUMENTS`, printing usage and exiting.

**This commit:** Add `arguments` parameter to fork dispatch in `_execute_fork`, thread it through preprocessing, ensuring fork skill bodies receive `$ARGUMENTS` fully populated.

**Pairs with:** amplifier-app-cli fix/forward-skill-arguments (PR #206) which instructs the model to forward the arguments parameter.

## The Opportunity (Commit a10d8a3)

Most fork skills need a clean slate (no parent context). But some could benefit from parent-session context without adding complexity.

**This commit:** Add `context_depth` and `context_scope` knobs to fork invocation (mirroring `delegate` tool), defaulting to `none` so existing skills are unaffected. Callers can opt-in by passing `context_depth='recent'` or `context_depth='all'` to explicitly inherit parent context. Scopes match delegate: `conversation` (text only), `agents` (+ delegate/task results), `full` (everything).

## Verification

Verified end-to-end in a Digital Twin Universe environment:

- **$ARGUMENTS delivery:** `/council review this idea: ...` forwarded arguments to fork skill; council's sub-session received `$ARGUMENTS='review this idea: ...'` and reviewed exactly that target
- **Empty-args case:** `/council` with no args still correctly prints usage (as intended)
- **Inline skills:** `/cranky-old-sam <arg>` also receive arguments (existing behavior preserved)
- **Context inheritance:** Tested with `context_depth=all` — parent turns correctly prepended before fork body
- **Default-none regression:** Existing fork skills receive no parent context by default (backward compatible)

**Test results:** 13/13 new tests pass (3 for $ARGUMENTS delivery, 10 for context inheritance). Full suite: 252 passed (no regressions beyond the 2 known pre-existing failures in unrelated code).

## Related PRs

- **amplifier-app-cli PR #206** (companion fix): Instructs the model to forward `arguments` to load_skill so the CLI half of the plumbing connects
- **amplifier-bundle-skills PR #30** (ramparte): Adds inline `council-here` skill + improves council's guard — only effective when $ARGUMENTS delivery (this PR + PR #206) lands

## Commit History

- `a10d8a3` feat(tool-skills): add optional parent-conversation context inheritance for fork skills
- `8380be4` feat(tool-skills): deliver $ARGUMENTS to fork skills (fixes council)

---

Generated with [Amplifier](https://github.com/microsoft/amplifier)
