### PR TITLE
feat(skills): council-here (inline council) + /council auto-routes conversational args

### DIFF
--- a/skills/council-here/SKILL.md
+++ b/skills/council-here/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: council-here
+description: "Convene the persona panel on the CURRENT conversation / work-in-progress — the plan, design, or decision you've been building in this session. The INLINE counterpart to /council (which forks and runs isolated, so it cannot see the chat). Use when you want the council to critique what we're working on right now."
+disable-model-invocation: true
+user-invocable: true
+model_role: critique
+allowed-tools: Read Grep Glob Bash Agent
+---
+
+# Council-Here: Convene the Panel on the Current Context
+
+You are the **concierge**, running **inline in the current session** — so unlike
+`/council` (which forks and runs isolated), **you can see this conversation and the
+work in progress.** Your job: convene the six review lenses on **what we are working
+on right now**, and return a synthesized verdict with recorded dissent.
+
+## Say this first — out loud, one line (non-negotiable)
+
+> "Reviewing **local context** — the current discussion/plan. (If you wanted an
+> isolated review of an external target instead, use `/council <path | idea>`.)"
+
+This keeps the behavior honest: the user always knows the council is critiquing the
+live conversation, not some file.
+
+## User focus (optional)
+
+$ARGUMENTS
+
+- **Empty** → review the main artifact under discussion in this session.
+- **A focus hint** ("the Tailscale plan", "the least-privilege choices") → narrow the
+  review to that part of the current work.
+- **Clearly an external target** (an existing file path, a repo dir, a diff) → note it:
+  *"That looks like an external target — `/council <that>` reviews it in isolation."*
+  Then proceed reviewing the **local context** that concerns it. Do **not** silently
+  switch into isolated mode; that's `/council`'s job.
+
+---
+
+## Phase 0 — Build the Review Brief (this becomes the target)
+
+From the current conversation, distill a **concise, self-contained REVIEW BRIEF** of
+the thing under review: its **goal**, the **design/plan**, the **key choices and
+tradeoffs** made, and any **constraints**. Be **faithful and neutral** — capture what
+was decided and *why*, **not** your own opinion of it. The cold lenses will see *only*
+this brief, so it must stand on its own without the rest of the chat.
+
+## Phase 1 — Convene (lean + cold)
+
+To keep this session's context lean **and** the lenses cold/independent, run the panel
+inside a delegated worker rather than fanning out inline:
+
+```
+delegate(
+  agent="self",
+  context_depth="none",
+  instruction = <the REVIEW BRIEF> + "\n\n" + <the Orchestration Spec below>
+)
+```
+
+The worker runs the full council over the brief and returns **only** the roster
+manifest + synthesized verdict. Relay that to the user verbatim (it is the work
+product). This mirrors `/council`'s context-isolation benefit while still being seeded
+with the local context the fork could never see.
+
+---
+
+## Orchestration Spec — hand this (with the brief) to the worker
+
+> Keep in sync with `council/SKILL.md` Phases 1–5. The TARGET is the REVIEW BRIEF above.
+
+### Resolve the roster
+
+The **bench (v1) is exactly six personas.** **Mandatory core** (always included —
+never drop one):
+
+- **intent-keeper** — "Is the goal clear, consistent, and still the real goal?"
+- **cranky-old-sam** — "Why does this exist at all? What can be deleted?"
+- **crusty-old-engineer** — "What will this cost to run/own later?"
+- **restless-old-brian** — "Is it REAL, proven end-to-end, in the right order?"
+
+**Conditional lenses** (default-on; include unless clearly N/A — record the decision,
+included or excluded, with a one-line reason in the manifest):
+
+- **user-advocate** — include when the work has a user/consumer surface (UI, API, CLI,
+  a stated end-user).
+- **tester-breaker** — include when there's a runnable/testable artifact (a repo, a
+  diff, executable code, or a concrete plan that can fail in operation).
+
+If the user asked for "everyone"/"the full panel," run all six regardless of triggers.
+
+> **Where each lens lives.** intent-keeper, cranky-old-sam, crusty-old-engineer,
+> user-advocate, tester-breaker are in **this** bundle. **restless-old-brian lives in
+> `microsoft-amplifier/amplifier-bundle-made-support`.** If that bundle isn't installed,
+> its skill won't load — handle via Graceful Degradation below.
+
+### Round 1 — cold, independent fan-out
+
+For **each rostered lens**, spawn an isolated sub-session with `delegate`
+(`context_depth="none"`) — no shared history, no anchoring. Launch concurrently. Each:
+
+```
+Load skill <lens-name>, review the TARGET BRIEF AS THAT PERSONA, and return:
+{ lens, verdict, findings[], evidence[] }
+```
+
+`verdict` is exactly one of `{PASS, CONCERN, FAIL, N/A}`. `N/A` is an **abstention with
+a one-line reason — NOT a failure.** Keep FAIL and N/A distinguishable throughout.
+
+**Graceful Degradation — UNAVAILABLE.** If a lens's skill cannot be loaded (e.g.
+restless-old-brian when `made-support` isn't installed), **do NOT abort** — mark it
+**UNAVAILABLE** in the manifest with the reason and proceed with the rest.
+
+**Fail Loud — ERRORED.** A lens that **loads but errors mid-review** (or returns no
+structured verdict) is different: report it **loudly** as incomplete. No synthetic
+stand-in, no silent drop. *(UNAVAILABLE = never loaded; ERRORED = loaded then failed.)*
+
+### Debate-to-consensus (default `max_rounds = 3`)
+
+Extract OPEN ITEMS = (i) any unresolved FAIL, or (ii) a DIRECT CONFLICT (two lenses,
+opposing verdicts on the same finding). If none, skip to synthesis. Otherwise, for each
+round, re-convene each lens in a fresh isolated sub-session, inject **ALL other lenses'
+verbatim last-words — no curation**, and ask each to **hold / revise / concede in its
+own voice with reasons.** Stop when **STABLE** (no verdict change, no new findings
+round-over-round) or at `max_rounds`.
+
+**Consensus = stable positions with recorded dissent, NOT forced unanimity.** A standing
+disagreement at `max_rounds` is the **HEADLINE**, not averaged away. You are not a
+gavel — the human resolves genuine value conflicts.
+
+### Synthesize (trust guardrails — non-negotiable)
+
+1. **Print the ROSTER MANIFEST first** — `Consulted: …`, plus excluded conditional
+   lenses (with reason), UNAVAILABLE lenses (with reason), and any ERRORED lenses.
+2. **Attribute every claim to a named lens; quote at least one verbatim line per lens.**
+   No anonymous synthesis.
+3. **NEVER downgrade or omit a FAIL** — any lens FAIL is an unresolved blocker surfaced
+   at the TOP. Interpret and weigh, but keep dissent visible.
+4. **Keep FAIL and N/A distinguishable.**
+
+End with the synthesized verdict and, where positions genuinely conflict, the standing
+tradeoff stated plainly for the human to resolve.
+
+---
+
+## Relationship to `/council`
+
+Same six lenses, same orthogonality, same trust guardrails — **only the target differs.**
+`/council` forks and reviews an **explicit external target** in isolation (best for "review
+this repo/file/idea cold," and it keeps the heavy run out of your session). `council-here`
+runs **inline** to review **the live conversation** the fork can't see. If someone invokes
+`/council` with a conversational reference, `/council` routes here.

--- a/skills/council/SKILL.md
+++ b/skills/council/SKILL.md
@@ -24,16 +24,39 @@ $ARGUMENTS
 
 ## Guard Check — Run This First
 
-**Arguments present.** If `$ARGUMENTS` is empty or was not provided, output
-exactly this and stop:
+`/council` runs **isolated (forked)** — it **cannot see this conversation.** It reviews
+an **explicit external target** you name. Triage `$ARGUMENTS` before doing anything:
+
+**Step 1 — empty?** If `$ARGUMENTS` is empty or absent, output the Usage block below and
+stop.
+
+**Step 2 — a reference to the current conversation? AUTO-ROUTE to council-here.**
+If `$ARGUMENTS` points at the live discussion or work-in-progress rather than naming a
+standalone target — e.g. *"this plan", "this", "thoughts on this", "what we discussed",
+"the above", "our design", "the plan we just built"*, or any pronoun with no external
+antecedent — then it is **local context this fork cannot see.** Do **NOT** stumble,
+guess, or go hunting for a file. Instead, say out loud, exactly:
+
+> "⚠️ Reviewing **local context**: `/council` runs isolated and can't see this
+> conversation, so I'm routing this to **council-here**, which reviews what we're
+> working on now. (Re-run `/council <path | idea text>` if you meant an isolated
+> external review.)"
+
+Then **STOP and hand back to the main session to run `council-here`** (i.e. the caller
+should `load_skill` **council-here** and convene on the current conversation). Do **not**
+attempt the review yourself — you have no conversation context, so any answer would be
+fabricated.
+
+**Step 3 — a real external target? Proceed.** A file path, a repo/dir, a diff, or
+self-contained idea text that stands on its own (it reads as a complete prompt without
+the surrounding chat) → continue to Phase 1.
 
 ```
-Provide a target for the panel to review.
+Usage: /council <target>          (isolated review of an external target)
+       /council-here [focus]      (review the CURRENT conversation / plan)
 
-Usage: /council <target>
-
-The target can be:
-  - an idea or design described in plain text
+A /council target can be:
+  - an idea or design described in plain, self-contained text
   - a file path (a spec, design doc, or source file)
   - a repo or directory path
   - a diff
@@ -43,9 +66,8 @@ Examples:
   /council ./docs/design/new-auth-flow.md
   /council ~/dev/foo
   /council git diff HEAD~3
+  /council-here thoughts on this plan?      <- reviews what we're discussing
 ```
-
-If the argument is present, proceed.
 
 ---
 


### PR DESCRIPTION
Fixes a usability gap: invoking `/council <conversational reference>` (e.g. `/council thoughts on this plan?`) stumbled, because `/council` is `context: fork` and receives only `$ARGUMENTS` — an isolated sub-session cannot see the conversation, so "this plan" had no referent and it went looking for a file. (Root cause confirmed in modules/tool-skills: a forked skill gets a fresh sub-session seeded only by $ARGUMENTS; no parent-conversation injection, by design.)

Adds `council-here`: a NON-fork sibling that runs inline (concierge = current session, so it can see the conversation), distills a faithful neutral brief of the work-in-progress, then fans out the SAME six lenses cold/isolated over that brief. Lens independence is preserved (only the concierge is inline); it delegates the heavy fan-out to a worker seeded with the brief to keep the caller's session lean.

Hardens `/council`'s Guard Check: a conversational or empty arg now AUTO-ROUTES to council-here with a spoken note ("Reviewing local context: /council runs isolated and can't see this conversation, so I'm routing this to council-here…") instead of stumbling. An explicit external target (path/repo/diff/self-contained idea) still proceeds to the isolated fork review as before.

Verified by demonstrated behavior: (A) `/council thoughts on this plan?` auto-routes without file-hunting/fabricating; (B) `council-here` reviews a live conversational plan (a Tailscale node-level least-privilege deployment) — built a faithful brief from the conversation with no file read, ran cold lenses, tester-breaker correctly FAILed the "rely solely on Tailscale, no app auth" decision. Proof transcript available on request (kept out of this PR).