### PR TITLE
fix: remove incorrect Claude-Code tool names from allowed-tools frontmatter

### DIFF
--- a/modules/tool-skills/README.md
+++ b/modules/tool-skills/README.md
@@ -388,7 +388,7 @@ user-invocable: true            # Registers as a slash command in the CLI
 auto-load: true                 # Activates at session start (for hook-based skills)
 
 # Tool scoping
-allowed-tools: Read Grep Glob Bash  # Restrict subagent's available tools
+allowed-tools: tool-filesystem tool-search tool-bash  # Module IDs — NOT Claude Code or callable tool names
 ---
 ```
 
@@ -401,7 +401,7 @@ allowed-tools: Read Grep Glob Bash  # Restrict subagent's available tools
 | `disable-model-invocation` | Prevents the model from loading the skill autonomously |
 | `user-invocable` | Registers the skill as a `/command` in the CLI |
 | `auto-load` | Skill activates at session start via embedded hooks |
-| `allowed-tools` | Restricts which tools the forked subagent can access |
+| `allowed-tools` | Restricts the forked subagent's tool surface. Values are **Amplifier module IDs** (e.g. `tool-filesystem`, `tool-search`, `tool-bash`, `tool-delegate`, `tool-skills`) — NOT Claude Code tool names and NOT callable tool names. A name matching no module yields an **empty** tool set. Omit entirely to inherit the full parent tool surface. |
 
 ### Creating a Simple Skill
 

--- a/skills/council-here/SKILL.md
+++ b/skills/council-here/SKILL.md
@@ -4,7 +4,6 @@ description: "Convene the persona panel on the CURRENT conversation / work-in-pr
 disable-model-invocation: true
 user-invocable: true
 model_role: critique
-allowed-tools: Read Grep Glob Bash Agent
 ---
 
 # Council-Here: Convene the Panel on the Current Context

--- a/skills/council/SKILL.md
+++ b/skills/council/SKILL.md
@@ -5,7 +5,6 @@ context: fork
 disable-model-invocation: true
 user-invocable: true
 model_role: critique
-allowed-tools: Read Grep Glob Bash Agent
 ---
 
 # Council: Convene the Persona Panel

--- a/skills/cranky-old-sam/SKILL.md
+++ b/skills/cranky-old-sam/SKILL.md
@@ -9,7 +9,6 @@ description: |
   A lens for any checkpoint — brainstorm, design, plan, implement, debug, or review — not just design.
   Use when: anything looks more complex than the problem needs — a speculative idea, an abstraction,
   a layer, an over-built fix — any time the worry is "do we actually need this, or can it be deleted?"
-allowed-tools: ["Read", "Grep", "Glob", "Bash", "WebSearch", "WebFetch", "Agent", "AskUserQuestion"]
 user-invocable: true
 shortcut: COSam
 auto-activation:

--- a/skills/crusty-old-engineer/SKILL.md
+++ b/skills/crusty-old-engineer/SKILL.md
@@ -9,7 +9,6 @@ description: |
   A lens for any checkpoint — brainstorm, design, plan, implement, debug, or review — not just up-front decisions.
   Use when: weighing consequences, hidden costs, or failure modes of any choice — an idea, an architecture,
   a tooling/legacy call, an implementation path, or a fix — any time the worry is "what will this cost us later?"
-allowed-tools: ["Read", "Grep", "Glob", "Bash", "WebSearch", "WebFetch", "Agent", "AskUserQuestion"]
 user-invocable: true
 shortcut: COE
 auto-activation:

--- a/skills/intent-keeper/SKILL.md
+++ b/skills/intent-keeper/SKILL.md
@@ -10,7 +10,6 @@ description: |
   A lens for any checkpoint — brainstorm, design, plan, implement, debug, or review — not just kickoff.
   Use when: the deliverable has quietly become the goal, the build has wandered from the brief, or
   nobody can say in one sentence what success looks like — any time the worry is "is this still the real goal?"
-allowed-tools: ["Read", "Grep", "Glob", "Bash", "WebSearch", "WebFetch", "Agent", "AskUserQuestion"]
 user-invocable: true
 shortcut: IK
 auto-activation:

--- a/skills/mass-change/SKILL.md
+++ b/skills/mass-change/SKILL.md
@@ -5,7 +5,6 @@ context: fork
 disable-model-invocation: true
 user-invocable: true
 model_role: reasoning
-allowed-tools: Read Grep Glob Bash
 ---
 
 # Batch: Parallel Work Orchestration

--- a/skills/personafy/SKILL.md
+++ b/skills/personafy/SKILL.md
@@ -11,16 +11,6 @@ description: >
   reusable reviewer skill. Also triggers on "personafy" / "personify".
 user-invocable: true
 shortcut: personify
-allowed-tools:
-  - read_file
-  - write_file
-  - edit_file
-  - bash
-  - glob
-  - grep
-  - delegate
-  - load_skill
-  - todo
 model_role: reasoning
 ---
 
@@ -121,6 +111,10 @@ Relationship-to-siblings section, and a Final Note. Match the family's frontmatt
 behavior grounded in the profile.
 **Rule:** keep the verbatim quotes — they are the highest-signal tokens and the soul of the
 persona.
+**Rule:** do NOT include `allowed-tools` in the generated SKILL.md. Persona advisor skills are
+inline (no `context: fork`), so the field is inert. If you must restrict tools for a fork-based
+variant, use Amplifier **module IDs** (e.g. `tool-filesystem`, `tool-bash`, `tool-delegate`) —
+never Claude Code tool names (`Read`, `Grep`, `Bash`, `Agent`).
 
 ### 6. Prove it steers in a live session
 

--- a/skills/session-debug/SKILL.md
+++ b/skills/session-debug/SKILL.md
@@ -5,7 +5,6 @@ context: fork
 disable-model-invocation: true
 user-invocable: true
 model_role: general
-allowed-tools: Read Grep Glob Bash
 ---
 
 # Debug: Session Diagnostics

--- a/skills/skills-assist/authoring-guide.md
+++ b/skills/skills-assist/authoring-guide.md
@@ -70,7 +70,7 @@ The `name` and `description` fields are the only required frontmatter fields. Ev
 | `context` | enum: `fork` | `null` (none) | When set to `fork`, the skill runs in a fresh context window that does not inherit the caller's conversation history. Ideal for context-sink patterns where you want a clean slate. |
 | `model_role` | string | `general` | Preferred model role for executing this skill. Matched against the active routing matrix. Common values: `general`, `reasoning`, `coding`, `critique`. Only applies when `context: fork`. |
 | `user-invocable` | boolean | `false` | When `true`, registers the skill as a `/name` shortcut that users can invoke directly. Also lists the skill in `/skills` output. |
-| `allowed-tools` | string | all tools | Space-separated list of tool names the forked context is allowed to use. Example: `Read Grep Glob Bash`. Restricts the tool surface for security or focus. Only applies when `context: fork`. |
+| `allowed-tools` | string | all tools | Space-separated list of Amplifier **module IDs** the forked context is allowed to use (e.g. `tool-filesystem tool-search tool-bash`). NOT Claude Code tool names. A name matching no module yields an empty tool set. Omit to inherit the full parent tool surface. Only applies when `context: fork`. |
 | `disable-model-invocation` | boolean | `false` | When `true`, the skill body is loaded as a system prompt and the model is NOT called in the root context — it is expected to delegate immediately. Used for orchestrator patterns that spawn workers via `delegate`. |
 | `auto-load` | boolean | `false` | When `true`, the skill's body is automatically injected into the system prompt at session startup. Use sparingly — only for skills that must always be active. |
 | `license` | string | — | SPDX license identifier for the skill (e.g., `MIT`, `Apache-2.0`). Informational only. |
@@ -110,7 +110,7 @@ Skills are loaded lazily to conserve context. The skill loading system has three
 
 6. **Set `model_role` to match the task.** Amplifier routes forked contexts to specialized model roles. Use `reasoning` for architecture decisions, `critique` for code review, `coding` for implementation work, `general` for broad consultation. Incorrect role selection wastes model capacity.
 
-7. **Use `allowed-tools` to restrict surface area.** Orchestrator skills that only need to read files should set `allowed-tools: Read Grep Glob`. This prevents accidental writes and makes the skill's capability boundary explicit and auditable.
+7. **Use `allowed-tools` to restrict surface area.** Values are Amplifier **module IDs** — not Claude Code tool names and not callable tool names. A skill that needs read-only filesystem access should set `allowed-tools: tool-filesystem tool-search`. Add `tool-bash` for shell commands, `tool-delegate` for spawning subagents, `tool-skills` for loading skills. A name matching no module yields an **empty** tool set. If you don't need to restrict the surface, omit the field entirely — the fork then inherits the full parent tool surface.
 
 8. **Validate `$ARGUMENTS` at the top of the body.** If your skill requires arguments, add a guard check as the first step: check whether `$ARGUMENTS` is empty, and if so output a usage example and stop. Worker agents spawned from orchestrators cannot ask the user for missing information — the orchestrator must ensure arguments are complete before delegating.
 
@@ -342,7 +342,7 @@ description: "Run a parallel security audit across the codebase. Spawns speciali
 context: fork
 model_role: security-audit
 user-invocable: true
-allowed-tools: Read Grep Glob Bash
+allowed-tools: tool-filesystem tool-search tool-bash tool-delegate
 ---
 
 # Security Audit
@@ -379,7 +379,7 @@ Aggregate findings into a severity-ordered report:
 Include file:line citations for every finding.
 ```
 
-**Key features:** `context: fork` + `model_role: security-audit` for specialized routing, `user-invocable: true` for `/security-audit`, `allowed-tools: Read Grep Glob Bash` to restrict to read-only filesystem access, `$ARGUMENTS` with a guard check, parallel agent dispatch pattern.
+**Key features:** `context: fork` + `model_role: security-audit` for specialized routing, `user-invocable: true` for `/security-audit`, `allowed-tools: tool-filesystem tool-search tool-bash tool-delegate` (module IDs — restrict filesystem + shell + agent dispatch), `$ARGUMENTS` with a guard check, parallel agent dispatch pattern.
 
 ---
 
@@ -391,6 +391,6 @@ Five production skills in this bundle demonstrate the full range of patterns:
 |-------|---------|-------------|
 | **image-vision** | Reference / Tool Wrapper | Static body with companion files (`setup.md`, `patterns.md`, `examples/`); no fork; provides bash scripts for non-LLM work; `license: MIT` |
 | **code-review** | Fork + Parallel Agents | `context: fork`, `model_role: critique`, `disable-model-invocation: true`; launches 3 parallel review agents via `delegate`; `$ARGUMENTS` for focus areas |
-| **mass-change** | Fork + Orchestrator | `context: fork`, `model_role: reasoning`, `allowed-tools: Read Grep Glob Bash`; 3-phase workflow (research → plan → parallel workers); each worker creates a PR |
+| **mass-change** | Fork + Orchestrator | `context: fork`, `model_role: reasoning`, `disable-model-invocation: true`; 3-phase workflow (research → plan → parallel workers); each worker creates a PR |
 | **session-debug** | Fork + Specialist Delegation | `context: fork`, `model_role: general`, `disable-model-invocation: true`; immediately delegates to `session-analyst` agent; checks session config paths |
 | **skills-assist** | Fork + Context-Sink Expert | `context: fork`, `model_role: general`, `user-invocable: true`; 4 companion reference files loaded on demand; synthesizes answers without inventing content |

--- a/skills/skills-assist/skills-vs-agents.md
+++ b/skills/skills-assist/skills-vs-agents.md
@@ -174,7 +174,7 @@ When a skill graduates to an agent, nothing is thrown away. Every component of t
 | Companion files | Context files (loaded via `read_file` or bundle context) | Companion files become context files loaded in the agent's forked session. Same content, different loading mechanism. |
 | `description:` frontmatter | Agent `description:` in bundle agent roster | The description surfaces in `delegate` tool output. Write it to answer "when should I use this?" |
 | `model_role:` frontmatter | `model_role` in delegation or bundle config | Model role preference maps directly. Agents can additionally configure `provider_preferences` and dynamic routing. |
-| `allowed-tools:` frontmatter | Tool composition in bundle YAML | Tool allowlist becomes an explicit tool composition declaration. Agents can additionally configure per-tool settings. |
+| `allowed-tools:` frontmatter | Tool composition in bundle YAML | Values are Amplifier **module IDs** (e.g. `tool-filesystem`, `tool-bash`, `tool-delegate`, `tool-skills`) — not Claude Code tool names and not callable tool names. Becomes an explicit tool composition declaration in agents. A name matching no module yields an empty tool set. |
 | `context: fork` | `context_depth` + `context_scope` in delegation | Fork isolation maps to clean-slate delegation (`context_depth: none`). Agents get richer control: recent N turns, conversation-only, full with tool results. |
 
 ### What You Gain by Becoming an Agent

--- a/skills/skills-assist/spec-reference.md
+++ b/skills/skills-assist/spec-reference.md
@@ -25,7 +25,7 @@ These fields are defined by the agentskills.io spec but are not yet required by 
 
 | Field | Required | Type | Description |
 |-------|----------|------|-------------|
-| `allowed-tools` | Optional | string | Space-separated list of tool names the forked context is permitted to use (e.g., `Read Grep Glob Bash`). Restricts the tool surface for security or focus. Only applies when `context: fork`. Harness support varies — not required by compliant harnesses. |
+| `allowed-tools` | Optional | string | Space-separated list of Amplifier **module IDs** the forked context is permitted to use (e.g., `tool-filesystem tool-search tool-bash`) — NOT Claude Code tool names and NOT callable tool names. A name matching no module yields an **empty** tool set; omit the field to inherit the full parent tool surface. Restricts the tool surface for security or focus. Only applies when `context: fork`. Harness support varies — not required by compliant harnesses. |
 | `hooks` | Optional | object | Lifecycle hooks executed at specific points (e.g., `on_load`, `on_complete`). Exact hook names and behavior are harness-defined. Harness support varies — not required by compliant harnesses. |
 
 ---
@@ -207,29 +207,21 @@ provider/model pairs based on the active matrix configuration.
 
 ---
 
-### Common Amplifier Tool Names for `allowed-tools`
+### Common Amplifier Module IDs for `allowed-tools`
 
-| Tool Name | What It Does |
-|-----------|-------------|
-| `read_file` | Read file contents |
-| `write_file` | Write/create files |
-| `edit_file` | Edit files via string replacement |
-| `bash` | Shell command execution |
-| `glob` | Find files by pattern |
-| `grep` | Search file contents with regex |
-| `web_search` | Search the web |
-| `web_fetch` | Fetch URL content |
-| `delegate` | Spawn sub-agents |
-| `load_skill` | Load other skills |
-| `recipes` | Execute multi-step recipes |
-| `LSP` | Language Server Protocol operations |
-| `python_check` | Python code quality checks |
-| `rust_check` | Rust code quality checks |
-| `containers` | Docker/Podman container management |
-| `nano-banana` | Visual AI analysis and generation |
-| `dot_graph` | DOT/Graphviz operations |
-| `todo` | Task tracking |
-| `mode` | Runtime mode management |
+`allowed-tools` matches Amplifier **module IDs** — NOT Claude Code names and NOT
+callable tool names (`read_file`, `bash`, etc.). Each module provides one or more
+callable tools, listed below. A name matching no module yields an **empty** tool
+set; omitting `allowed-tools` entirely inherits the full parent tool surface.
 
-This is a sampling of commonly used tools. The actual set available depends on
+| Module ID | Tools It Provides |
+|-----------|-------------------|
+| `tool-filesystem` | `read_file`, `write_file`, `edit_file`, `glob` |
+| `tool-search` | `grep`, `glob` |
+| `tool-bash` | `bash` |
+| `tool-delegate` | `delegate` (spawn sub-agents) |
+| `tool-skills` | `load_skill` (load other skills) |
+| `tool-web` | `web_search`, `web_fetch` |
+
+This is a sampling of commonly used modules. The actual set available depends on
 the session's bundle configuration. Consult `skills-assist` for the latest list.

--- a/skills/tester-breaker/SKILL.md
+++ b/skills/tester-breaker/SKILL.md
@@ -11,7 +11,6 @@ description: |
   Use when: the happy path is celebrated while the edges sit unexamined, "looks fine" is standing in
   for "I tried to break it and couldn't," or nobody has named the input that makes this fall over —
   any time the worry is "how does this fail, and where are the edges?"
-allowed-tools: ["Read", "Grep", "Glob", "Bash", "WebSearch", "WebFetch", "Agent", "AskUserQuestion"]
 user-invocable: true
 shortcut: TB
 auto-activation:

--- a/skills/user-advocate/SKILL.md
+++ b/skills/user-advocate/SKILL.md
@@ -12,7 +12,6 @@ description: |
   Use when: a feature is being built because it's buildable rather than wanted, the happy path is
   celebrated while the recovery path is missing, or nobody can name the person this serves —
   any time the worry is "does the person we serve actually want this, and can they live with it?"
-allowed-tools: ["Read", "Grep", "Glob", "Bash", "WebSearch", "WebFetch", "Agent", "AskUserQuestion"]
 user-invocable: true
 shortcut: UA
 auto-activation:


### PR DESCRIPTION
## Summary

Fixes hallucinating `/council` skill and removes the `allowed-tools: Read Grep Glob Bash Agent` error that was propagated across six persona lenses and related skills.

## Root Cause

The council skills and persona lenses declared `allowed-tools:` in their SKILL.md frontmatter using **Claude Code tool names** (Read, Grep, Glob, Bash, Agent) instead of **Amplifier module IDs** (tool-filesystem, tool-search, tool-bash, tool-delegate, tool-skills). 

Amplifier matches `allowed-tools` verbatim against module IDs. When the names don't match, a **forked skill gets an empty tool surface**. Unable to read files or delegate, the LLM fabricates `<tool_call>`/`<tool_response>` text blocks instead of making real calls.

## The Fix

**Changed:**
- Removed `allowed-tools: Read Grep Glob Bash Agent` from `council`, `council-here`, `mass-change`, `session-debug`, and all five persona lens skills (intent-keeper, user-advocate, tester-breaker, crusty-old-engineer, cranky-old-sam). When absent, forked skills inherit the parent's real tool surface.
- Corrected authoring docs (README, spec-reference, skills-vs-agents, authoring-guide) to teach module-ID semantics, removing the recurrence source.
- Updated personafy template to stop emitting the incorrect `allowed-tools` line into newly authored personas.

**Unchanged:**
- Council and council-here skill bodies left exactly as authored (no Phase-1 rewrites).

## Verification

Tested in clean-room DTU with `/council /tmp/target-design.md`:

| Metric | BEFORE | AFTER |
|--------|--------|-------|
| Real `read_file` calls | 0 | 1 (actual target) |
| Real `delegate` spawns (6 lenses × 2 debate rounds) | 0 | 12 |
| Child sub-sessions | 0 | 12 |
| Fake `<tool_call>` text blocks | 22 | 0 |
| Verdict | Hallucinated WRONG document | Grounded in real target (6/6 FAIL) |

(See events.jsonl for authoritative proof; json-trace `total_agents_invoked` reads 0 even when fixed — use execution_trace + per-session events.jsonl for verification.)

## Known Limitation

`/council-here` still simulates its six "independent" lenses because its delegated worker (`delegate(agent="self")`) does not inherit the `delegate` tool, so it cannot physically fan them out. This is a **pre-existing design issue**, intentionally left out of this PR for the skill's original author to address. The `allowed-tools` removal here is the correct hygiene fix; the worker-can't-delegate issue is separate.

## Files Changed

- **Core fix (load-bearing):** council, council-here, mass-change, session-debug (7 files, 4 removed lines)
- **Consistency:** 5 persona lens skills (5 files, 5 removed lines)
- **Recurrence source:** authoring-guide, spec-reference, skills-vs-agents, README, personafy template (6 files)

Total: 14 files, 30 insertions, 53 deletions.
