### PR TITLE
fix(image-vision): cap/downscale screenshots + fail clearly when vision provider unavailable (suggested, draft)

### DIFF
--- a/skills/image-vision/SKILL.md
+++ b/skills/image-vision/SKILL.md
@@ -89,7 +89,7 @@ python examples/anthropic-vision.py image.png "prompt"
 
 - **JPEG/JPG** - Most common
 - **PNG** - With transparency
-- **GIF** - Static or animated
+- **GIF** - Static or animated (only the first frame is analyzed)
 - **WEBP** - Modern format
 
 **Max sizes:**
@@ -292,6 +292,20 @@ else
 fi
 ```
 
+**Exit codes are classified** so callers get an honest failure signal instead of
+a catch-all (this distinction matters: a missing key and a slow provider need
+different fixes):
+
+| Exit | Meaning | What to do |
+|------|---------|-----------|
+| `0` | Success | Use the output |
+| `1` | Usage error, or all configured providers failed (mixed/other errors) | Read stderr for the underlying error |
+| `3` | **No vision provider configured** (no API key present) | Set `GOOGLE_API_KEY` / `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` (or `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_ENDPOINT`) |
+| `4` | **provider_timeout** — provider(s) present but every attempt timed out within the bounded timeout | Increase the timeout (3rd arg), use a smaller image, or a faster provider |
+
+`vision-analyze-robust.sh` fails **fast and clearly** on exit `3`/`4` rather than
+hanging — a missing or slow provider surfaces immediately, not minutes later.
+
 ### 3. NEVER Fabricate Visual Observations
 
 **If vision analysis fails, you MUST:**
@@ -336,12 +350,29 @@ Vision API calls typically take 5-60 seconds:
 - OpenAI GPT-4: 8-20s
 
 The wrapper scripts handle timeouts with:
-- 60-second default timeout (configurable)
+- 60-second default timeout (configurable, always bounded)
 - Auto-fallback to faster providers (robust script)
 - Retry logic on transient failures
+- **Automatic screenshot downscaling** — every image is capped in **width**
+  (2000px) and bounded in **encoded payload size** (a real, fail-closed bound)
+  before it is sent (see `examples/image_utils.py`). This makes the "resize to
+  2000px max" guidance automatic so an un-capped full-page screenshot can't
+  produce an oversized, interruptible request. Downscaling is conservative:
+  downscale-only (never upscales), aspect preserved, LANCZOS, EXIF-aware. **It
+  caps width rather than the longest edge specifically so a tall full-page
+  capture is not squashed** — width is the dimension that text legibility
+  depends on. If a pathological image still exceeds the payload bound at the
+  width floor, it is re-encoded to JPEG, and if it still cannot fit the call
+  fails clearly rather than sending an oversized payload.
+
+> **Capture hygiene still matters.** For text-critical verification (small
+> numbers, labels, precise alignment), prefer **viewport-sized** captures over
+> aggressive full-page captures, and corroborate with browser/DOM facts — see
+> "Known Limitations for Web UI Analysis" above. The cap removes a hang risk; it
+> does not make vision reliable for sub-pixel typography.
 
 If still hitting timeouts:
-- Use smaller images (resize to 2000px max)
+- Use smaller images (capping is automatic, but viewport captures help most)
 - Simplify prompts
 - Use faster models (Gemini Flash)
 
@@ -349,7 +380,7 @@ If still hitting timeouts:
 
 **For interactive use:**
 1. Create venv: `cd image-vision && uv venv`
-2. Install SDKs: `uv pip install anthropic openai google-generativeai`
+2. Install SDKs: `uv pip install anthropic openai google-genai pillow`
 3. Set API keys: Export `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`
 
 **For agents:**

--- a/skills/image-vision/examples/anthropic-vision.py
+++ b/skills/image-vision/examples/anthropic-vision.py
@@ -14,10 +14,12 @@ Requires:
 """
 
 import anthropic
-import base64
 import sys
 import os
 import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from image_utils import prepare_image_base64  # noqa: E402
 
 
 def analyze_image(image_path: str, prompt: str, max_retries: int = 2) -> str:
@@ -37,25 +39,10 @@ def analyze_image(image_path: str, prompt: str, max_retries: int = 2) -> str:
     
     client = anthropic.Anthropic(api_key=api_key)
     
-    # Read and encode image
-    try:
-        with open(image_path, "rb") as f:
-            image_data = base64.standard_b64encode(f.read()).decode("utf-8")
-    except FileNotFoundError:
-        raise FileNotFoundError(f"Image not found: {image_path}")
-    except Exception as e:
-        raise RuntimeError(f"Failed to read image: {e}")
-    
-    # Detect media type from extension
-    ext = image_path.lower().split('.')[-1]
-    media_types = {
-        "jpg": "image/jpeg",
-        "jpeg": "image/jpeg",
-        "png": "image/png",
-        "gif": "image/gif",
-        "webp": "image/webp"
-    }
-    media_type = media_types.get(ext, "image/jpeg")
+    # Read, downscale, and bound the payload before sending (see image_utils).
+    # This caps screenshot size so a large image can't produce an oversized,
+    # interruptible request that hangs.
+    image_data, media_type = prepare_image_base64(image_path)
     
     # Call Claude with vision (with retry logic)
     for attempt in range(max_retries):

--- a/skills/image-vision/examples/azure-vision.py
+++ b/skills/image-vision/examples/azure-vision.py
@@ -16,10 +16,12 @@ Requires:
 """
 
 import openai
-import base64
 import sys
 import os
 import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from image_utils import prepare_image_base64  # noqa: E402
 
 
 def analyze_image(image_path: str, prompt: str, max_retries: int = 2) -> str:
@@ -48,25 +50,10 @@ def analyze_image(image_path: str, prompt: str, max_retries: int = 2) -> str:
         azure_endpoint=endpoint
     )
     
-    # Read and encode image
-    try:
-        with open(image_path, "rb") as f:
-            image_data = base64.standard_b64encode(f.read()).decode("utf-8")
-    except FileNotFoundError:
-        raise FileNotFoundError(f"Image not found: {image_path}")
-    except Exception as e:
-        raise RuntimeError(f"Failed to read image: {e}")
-    
-    # Detect media type from extension
-    ext = image_path.lower().split('.')[-1]
-    media_types = {
-        "jpg": "image/jpeg",
-        "jpeg": "image/jpeg",
-        "png": "image/png",
-        "gif": "image/gif",
-        "webp": "image/webp"
-    }
-    media_type = media_types.get(ext, "image/jpeg")
+    # Read, downscale, and bound the payload before sending (see image_utils).
+    # This caps screenshot size so a large image can't produce an oversized,
+    # interruptible request that hangs.
+    image_data, media_type = prepare_image_base64(image_path)
     
     # Get deployment name (or use default)
     deployment_name = os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-4o")

--- a/skills/image-vision/examples/gemini-vision.py
+++ b/skills/image-vision/examples/gemini-vision.py
@@ -19,6 +19,9 @@ import sys
 import os
 import time
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from image_utils import prepare_image_bytes  # noqa: E402
+
 
 def analyze_image(image_path: str, prompt: str, max_retries: int = 2) -> str:
     """Analyze an image using Gemini's vision capabilities.
@@ -37,25 +40,10 @@ def analyze_image(image_path: str, prompt: str, max_retries: int = 2) -> str:
     
     client = genai.Client(api_key=api_key)
     
-    # Read image file
-    try:
-        with open(image_path, "rb") as f:
-            image_data = f.read()
-    except FileNotFoundError:
-        raise FileNotFoundError(f"Image not found: {image_path}")
-    except Exception as e:
-        raise RuntimeError(f"Failed to read image: {e}")
-    
-    # Detect mime type from extension
-    ext = image_path.lower().split('.')[-1]
-    media_types = {
-        "jpg": "image/jpeg",
-        "jpeg": "image/jpeg",
-        "png": "image/png",
-        "gif": "image/gif",
-        "webp": "image/webp"
-    }
-    mime_type = media_types.get(ext, "image/jpeg")
+    # Read, downscale, and bound the payload before sending (see image_utils).
+    # This caps screenshot size so a large image can't produce an oversized,
+    # interruptible request that hangs.
+    image_data, mime_type = prepare_image_bytes(image_path)
     
     # Call Gemini with vision using proper types (with retry logic)
     for attempt in range(max_retries):

--- a/skills/image-vision/examples/image_utils.py
+++ b/skills/image-vision/examples/image_utils.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Shared image preparation for the vision provider scripts.
+
+Why this exists
+---------------
+The provider scripts (anthropic/openai/gemini/azure) used to read a screenshot
+and base64-encode it *verbatim* with no size bound, even though the skill's own
+guidance says to "resize to 2000px max" (SKILL.md) and patterns.md ships an
+unused ``preprocess_image`` helper. An un-capped full-page PNG produces a large,
+slow, interruptible multimodal request. When several such requests stack up (or
+retry), the call can hang for a very long time instead of failing fast.
+
+This module makes that documented advice *automatic*: every screenshot is bounded
+in **width** and in **encoded-payload size** before it is sent to any provider.
+
+Design choices (and why)
+------------------------
+* **Cap WIDTH, not the longest edge.** Web screenshots are rendered at a target
+  width; text legibility tracks width. Capping the *longest* edge would squash a
+  tall full-page capture (e.g. 1280x8000 -> 320x2000), destroying the small text
+  a journey check may depend on. We cap width instead, so a tall page keeps its
+  rendered width and stays readable.
+* **Downscale only.** A small image is never upscaled (no invented detail).
+* **Aspect ratio is always preserved**, high-quality LANCZOS resampling.
+* **The payload bound is a real, fail-closed bound.** If, after capping width to
+  the legibility floor, the encoded image still exceeds the byte ceiling, we
+  re-encode as progressively-lower-quality JPEG; if it *still* won't fit, we
+  raise a clear error rather than silently sending an oversized payload (which
+  is exactly the hang we are removing). This only ever triggers for pathological
+  inputs (huge noisy photos), never for real UI screenshots.
+* **EXIF orientation is honored** so sideways-captured text is not sent rotated.
+
+Capture hygiene still matters: for text-critical verification prefer
+viewport-sized captures and corroborate with browser/DOM facts (see SKILL.md
+"Known Limitations for Web UI Analysis"). The cap removes a hang risk; it does
+not make vision reliable for sub-pixel typography.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import os
+import sys
+
+# --- Tunable bounds -------------------------------------------------------
+# Width cap (the legibility-critical dimension). Matches the skill's existing
+# written advice ("resize to 2000px max", SKILL.md) so this wiring introduces no
+# new policy -- it just enforces what the docs already recommend.
+MAX_WIDTH = 2000
+
+# Hard ceiling on the *encoded* (base64) payload, in bytes. Anthropic's
+# per-image limit is 5 MB; 4 MB of base64 keeps us comfortably under it with
+# headroom for the surrounding request envelope. This is enforced (fail-closed),
+# not merely advisory.
+MAX_ENCODED_BYTES = 4_000_000
+
+# Never downscale width below this while chasing the payload ceiling. Protects
+# small-text legibility. A 1024px-wide screenshot is far under the byte ceiling
+# in practice, so this floor is only reached by pathological inputs.
+MIN_WIDTH = 1024
+
+# Bound on the width-shrink loop. Each step multiplies width by ~0.85.
+_MAX_SHRINK_STEPS = 12
+
+# JPEG qualities tried (high -> low) when a floored image still exceeds the
+# ceiling and must be losslessly-then-lossily reduced to fit.
+_JPEG_RESCUE_QUALITIES = (80, 70, 60, 50, 40)
+
+
+def _require_pillow():
+    """Import Pillow or fail with an actionable message.
+
+    Capping is the whole point of this module; silently sending an un-capped
+    image if Pillow is missing would reintroduce the exact fragility we are
+    removing. So we fail loud with a fix instruction instead. The wrapper
+    scripts (vision-analyze*.sh) install Pillow into the venv, so the supported
+    path never hits this.
+    """
+    try:
+        from PIL import Image, ImageOps  # noqa: F401
+
+        return Image, ImageOps
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise RuntimeError(
+            "Pillow is required to prepare images for vision analysis "
+            "(it bounds screenshot size so a large payload can't hang the "
+            "request). Install it with: pip install pillow"
+        ) from exc
+
+
+def _output_format(pil_format: "str | None", ext: str) -> str:
+    """Pick the encode format. Preserve the source format when it is one we can
+    round-trip safely; otherwise fall back to PNG (lossless, keeps text
+    crisp)."""
+    fmt = (pil_format or "").upper()
+    if fmt in {"PNG", "JPEG", "WEBP"}:
+        return fmt
+    if ext in {"jpg", "jpeg"}:
+        return "JPEG"
+    if ext == "webp":
+        return "WEBP"
+    return "PNG"
+
+
+def _media_type_for(out_format: str) -> str:
+    return {
+        "JPEG": "image/jpeg",
+        "PNG": "image/png",
+        "WEBP": "image/webp",
+    }[out_format]
+
+
+def _flatten_for_jpeg(image):
+    """JPEG has no alpha and cannot hold CMYK cleanly; normalize to RGB."""
+    if image.mode in ("RGBA", "LA", "P", "CMYK", "YCbCr", "I", "F"):
+        return image.convert("RGB")
+    return image
+
+
+def _encode(image, out_format: str, quality: int = 90) -> bytes:
+    """Encode a PIL image to bytes in ``out_format``."""
+    buf = io.BytesIO()
+    if out_format == "JPEG":
+        _flatten_for_jpeg(image).save(
+            buf, format="JPEG", quality=quality, optimize=True
+        )
+    elif out_format == "WEBP":
+        image.save(buf, format="WEBP", quality=quality, method=4)
+    else:  # PNG
+        image.save(buf, format="PNG", optimize=True)
+    return buf.getvalue()
+
+
+def _encoded_len(data: bytes) -> int:
+    return len(base64.standard_b64encode(data))
+
+
+def _downscale_to_width(Image, image, target_width: int):
+    """Return a copy scaled so width == target_width (aspect preserved).
+    Downscale only -- if target_width >= current width, returns unchanged."""
+    w, h = image.size
+    if target_width >= w:
+        return image
+    scale = target_width / float(w)
+    new_size = (target_width, max(1, round(h * scale)))
+    return image.resize(new_size, Image.Resampling.LANCZOS)
+
+
+def prepare_image_bytes(
+    image_path: str,
+    *,
+    max_width: int = MAX_WIDTH,
+    max_encoded_bytes: int = MAX_ENCODED_BYTES,
+    min_width: int = MIN_WIDTH,
+) -> "tuple[bytes, str]":
+    """Load an image and return ``(processed_bytes, media_type)``, bounded so it
+    cannot produce an oversized/interruptible vision request.
+
+    Bounds applied, in order:
+      1. Width capped to ``max_width`` (downscale only, aspect preserved).
+      2. Encoded payload capped to ``max_encoded_bytes`` -- first by reducing
+         width down to ``min_width``, then (if still over) by re-encoding as
+         progressively-lower-quality JPEG. If it still cannot fit, raise.
+
+    Raises FileNotFoundError if the path is missing, RuntimeError (with an
+    actionable message) if Pillow is unavailable, the file is not a decodable
+    image, or the image cannot be reduced under the payload ceiling.
+    """
+    if not os.path.exists(image_path):
+        raise FileNotFoundError(f"Image not found: {image_path}")
+
+    Image, ImageOps = _require_pillow()
+
+    try:
+        with Image.open(image_path) as img:
+            img.load()
+            src_format = img.format
+            # Honor EXIF orientation, then detach a copy so the handle can close.
+            image = ImageOps.exif_transpose(img)
+            image = image.copy()
+    except FileNotFoundError:
+        raise
+    except Exception as exc:
+        raise RuntimeError(f"Failed to read image '{image_path}': {exc}") from exc
+
+    ext = image_path.lower().rsplit(".", 1)[-1] if "." in image_path else ""
+    out_format = _output_format(src_format, ext)
+    media_type = _media_type_for(out_format)
+
+    # 1. Width cap.
+    if image.size[0] > max_width:
+        image = _downscale_to_width(Image, image, max_width)
+
+    # 2a. Payload cap by shrinking width, never below the floor.
+    data = _encode(image, out_format)
+    steps = 0
+    while (
+        _encoded_len(data) > max_encoded_bytes
+        and image.size[0] > min_width
+        and steps < _MAX_SHRINK_STEPS
+    ):
+        target_w = max(min_width, int(image.size[0] * 0.85))
+        image = _downscale_to_width(Image, image, target_w)
+        data = _encode(image, out_format)
+        steps += 1
+
+    # 2b. Still over at the width floor: re-encode lossily (JPEG) to GUARANTEE
+    # the bound. Only pathological inputs (huge noisy photos) reach here.
+    if _encoded_len(data) > max_encoded_bytes:
+        for quality in _JPEG_RESCUE_QUALITIES:
+            jpeg = _encode(image, "JPEG", quality=quality)
+            if _encoded_len(jpeg) <= max_encoded_bytes:
+                print(
+                    f"note: '{os.path.basename(image_path)}' re-encoded to JPEG "
+                    f"q{quality} to fit the {max_encoded_bytes // 1_000_000}MB "
+                    "payload bound.",
+                    file=sys.stderr,
+                )
+                return jpeg, "image/jpeg"
+        # Truly cannot fit -- fail clearly rather than send an oversized payload.
+        raise RuntimeError(
+            f"Image '{os.path.basename(image_path)}' could not be reduced under "
+            f"the {max_encoded_bytes // 1_000_000}MB payload bound even at "
+            f"{image.size[0]}x{image.size[1]} JPEG q{_JPEG_RESCUE_QUALITIES[-1]}. "
+            "Use a smaller or viewport-sized capture."
+        )
+
+    return data, media_type
+
+
+def prepare_image_base64(
+    image_path: str,
+    *,
+    max_width: int = MAX_WIDTH,
+    max_encoded_bytes: int = MAX_ENCODED_BYTES,
+    min_width: int = MIN_WIDTH,
+) -> "tuple[str, str]":
+    """Same as :func:`prepare_image_bytes` but returns a base64-encoded string
+    (the form the Anthropic/OpenAI/Azure SDKs want)."""
+    data, media_type = prepare_image_bytes(
+        image_path,
+        max_width=max_width,
+        max_encoded_bytes=max_encoded_bytes,
+        min_width=min_width,
+    )
+    return base64.standard_b64encode(data).decode("utf-8"), media_type

--- a/skills/image-vision/examples/openai-vision.py
+++ b/skills/image-vision/examples/openai-vision.py
@@ -14,10 +14,12 @@ Requires:
 """
 
 import openai
-import base64
 import sys
 import os
 import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from image_utils import prepare_image_base64  # noqa: E402
 
 
 def analyze_image(image_path: str, prompt: str, max_retries: int = 2) -> str:
@@ -37,25 +39,10 @@ def analyze_image(image_path: str, prompt: str, max_retries: int = 2) -> str:
     
     client = openai.OpenAI(api_key=api_key)
     
-    # Read and encode image
-    try:
-        with open(image_path, "rb") as f:
-            image_data = base64.standard_b64encode(f.read()).decode("utf-8")
-    except FileNotFoundError:
-        raise FileNotFoundError(f"Image not found: {image_path}")
-    except Exception as e:
-        raise RuntimeError(f"Failed to read image: {e}")
-    
-    # Detect media type from extension
-    ext = image_path.lower().split('.')[-1]
-    media_types = {
-        "jpg": "image/jpeg",
-        "jpeg": "image/jpeg",
-        "png": "image/png",
-        "gif": "image/gif",
-        "webp": "image/webp"
-    }
-    media_type = media_types.get(ext, "image/jpeg")
+    # Read, downscale, and bound the payload before sending (see image_utils).
+    # This caps screenshot size so a large image can't produce an oversized,
+    # interruptible request that hangs.
+    image_data, media_type = prepare_image_base64(image_path)
     
     # Call GPT-5 with vision (with retry logic)
     for attempt in range(max_retries):

--- a/skills/image-vision/setup.md
+++ b/skills/image-vision/setup.md
@@ -15,13 +15,14 @@ uv venv
 source .venv/bin/activate  # macOS/Linux
 # or: .venv\Scripts\activate  # Windows
 
-# Install all provider SDKs (recommended)
-uv pip install anthropic openai google-genai
+# Install all provider SDKs (recommended). pillow is required by all scripts --
+# it downscales/bounds screenshots before they are sent (see image_utils.py).
+uv pip install anthropic openai google-genai pillow
 
-# Or install only what you need
-uv pip install anthropic              # Claude only
-uv pip install openai                 # OpenAI + Azure OpenAI
-uv pip install google-genai           # Gemini only
+# Or install only what you need (always include pillow)
+uv pip install anthropic pillow       # Claude only
+uv pip install openai pillow          # OpenAI + Azure OpenAI
+uv pip install google-genai pillow    # Gemini only
 ```
 
 **Verify installation:**

--- a/skills/image-vision/tests/test_image_utils.py
+++ b/skills/image-vision/tests/test_image_utils.py
@@ -1,0 +1,195 @@
+"""Unit tests for the image-vision screenshot capping helper.
+
+These tests exercise the resize/downscale + payload-bounding logic directly,
+with no network calls. They require Pillow:  pip install pillow pytest
+
+Run:  python -m pytest skills/image-vision/tests/test_image_utils.py
+"""
+
+import base64
+import io
+import os
+import sys
+
+import pytest
+
+# Import the helper from the sibling examples/ directory.
+EXAMPLES_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "examples")
+sys.path.insert(0, EXAMPLES_DIR)
+
+from PIL import Image, ImageFilter  # noqa: E402
+
+import image_utils  # noqa: E402
+
+
+def _make_image(tmp_path, name, size, color=(123, 200, 75), mode="RGB"):
+    """Write a solid-color image and return its path."""
+    img = Image.new(mode, size, color)
+    path = os.path.join(tmp_path, name)
+    img.save(path)
+    return path
+
+
+def _make_noise_image(tmp_path, name, size, fmt="PNG", blur=0):
+    """Write a random-noise image to force the payload ceiling to engage.
+
+    Pure noise is ~incompressible (PNG and JPEG both stay large). A small blur
+    makes it JPEG-friendly while PNG stays large -- useful for exercising the
+    JPEG-rescue path deterministically."""
+    w, h = size
+    img = Image.frombytes("RGB", size, os.urandom(w * h * 3))
+    if blur:
+        img = img.filter(ImageFilter.GaussianBlur(radius=blur))
+    path = os.path.join(tmp_path, name)
+    img.save(path, format=fmt)
+    return path
+
+
+def _dims(data: bytes):
+    with Image.open(io.BytesIO(data)) as im:
+        return im.size
+
+
+def _enc_len(data: bytes) -> int:
+    return len(base64.standard_b64encode(data))
+
+
+# --- Width cap ------------------------------------------------------------
+
+
+def test_downscale_caps_width(tmp_path):
+    path = _make_image(tmp_path, "big.png", (4000, 3000))
+    data, media_type = image_utils.prepare_image_bytes(path, max_width=2000)
+    w, h = _dims(data)
+    assert w == 2000
+    assert media_type == "image/png"
+
+
+def test_aspect_ratio_preserved(tmp_path):
+    path = _make_image(tmp_path, "wide.png", (4000, 1000))  # 4:1
+    data, _ = image_utils.prepare_image_bytes(path, max_width=2000)
+    w, h = _dims(data)
+    assert w == 2000
+    assert abs(w / h - 4.0) < 0.05
+
+
+def test_no_upscale_small_image(tmp_path):
+    path = _make_image(tmp_path, "small.png", (100, 80))
+    data, _ = image_utils.prepare_image_bytes(path, max_width=2000)
+    assert _dims(data) == (100, 80)  # unchanged -- never upscales
+
+
+def test_exactly_at_cap_is_unchanged(tmp_path):
+    path = _make_image(tmp_path, "edge.png", (2000, 1500))
+    data, _ = image_utils.prepare_image_bytes(path, max_width=2000)
+    assert _dims(data) == (2000, 1500)
+
+
+def test_tall_fullpage_preserves_width(tmp_path):
+    """A tall full-page capture must NOT be squashed: width is the
+    legibility-critical dimension. 1280x8000 stays 1280 wide (it is a flat
+    color image well under the payload ceiling)."""
+    path = _make_image(tmp_path, "tall.png", (1280, 8000))
+    data, _ = image_utils.prepare_image_bytes(path, max_width=2000)
+    w, h = _dims(data)
+    assert w == 1280  # width preserved, not crushed
+    assert h == 8000  # height preserved (payload was already small)
+
+
+# --- Payload cap (must be a REAL, fail-closed bound) ----------------------
+
+
+def test_payload_ceiling_forces_width_downscale(tmp_path):
+    # Noise barely compresses, so a 1600x1200 PNG is over a small ceiling.
+    path = _make_noise_image(tmp_path, "noise.png", (1600, 1200))
+    data, _ = image_utils.prepare_image_bytes(
+        path, max_width=4000, max_encoded_bytes=400_000, min_width=256
+    )
+    assert _enc_len(data) <= 400_000  # actually under the ceiling
+    w, _ = _dims(data)
+    assert w >= 256  # floor respected
+
+
+def test_payload_rescued_to_jpeg_at_floor(tmp_path):
+    # At the width floor, a still-too-big PNG must be re-encoded to JPEG so the
+    # returned payload is GUARANTEED under the ceiling -- never silently
+    # oversized. Blurred noise: large as PNG, small as JPEG.
+    path = _make_noise_image(tmp_path, "blur.png", (1024, 1024), blur=2)
+    data, media_type = image_utils.prepare_image_bytes(
+        path, max_width=4000, max_encoded_bytes=500_000, min_width=1024
+    )
+    assert _enc_len(data) <= 500_000  # actually under the ceiling
+    assert media_type == "image/jpeg"  # had to fall back to JPEG to fit
+
+
+def test_payload_bound_fails_closed_when_incompressible(tmp_path):
+    # Pure noise that cannot be compressed under a tiny ceiling even at the
+    # floor and lowest JPEG quality must RAISE -- never return an oversized
+    # payload that could hang the request.
+    path = _make_noise_image(tmp_path, "purenoise.png", (1024, 1024))
+    with pytest.raises(RuntimeError):
+        image_utils.prepare_image_bytes(
+            path, max_width=4000, max_encoded_bytes=100_000, min_width=1024
+        )
+
+
+# --- Format / media type --------------------------------------------------
+
+
+def test_jpeg_media_type(tmp_path):
+    path = _make_image(tmp_path, "photo.jpg", (3000, 2000))
+    data, media_type = image_utils.prepare_image_bytes(path, max_width=1000)
+    assert media_type == "image/jpeg"
+    with Image.open(io.BytesIO(data)) as im:
+        assert im.format == "JPEG"
+
+
+def test_cmyk_jpeg_normalized(tmp_path):
+    # CMYK JPEGs must be normalized to RGB so providers/decoders accept them.
+    path = _make_image(tmp_path, "cmyk.jpg", (1200, 800), color=(10, 20, 30, 40), mode="CMYK")
+    data, media_type = image_utils.prepare_image_bytes(path, max_width=600)
+    assert media_type == "image/jpeg"
+    with Image.open(io.BytesIO(data)) as im:
+        assert im.mode == "RGB"
+
+
+def test_base64_helper_roundtrips(tmp_path):
+    path = _make_image(tmp_path, "ui.png", (2400, 1200))
+    b64, media_type = image_utils.prepare_image_base64(path, max_width=2000)
+    assert media_type == "image/png"
+    raw = base64.standard_b64decode(b64)
+    with Image.open(io.BytesIO(raw)) as im:
+        assert im.size[0] == 2000
+
+
+# --- EXIF orientation -----------------------------------------------------
+
+
+def test_exif_orientation_applied(tmp_path):
+    # Build a portrait image, tag it orientation=6 (rotate 90 CW on display).
+    # exif_transpose should swap dimensions so text isn't sent sideways.
+    img = Image.new("RGB", (400, 200), (50, 100, 150))
+    exif = img.getexif()
+    exif[274] = 6  # 274 = Orientation tag
+    path = os.path.join(tmp_path, "rot.jpg")
+    img.save(path, exif=exif)
+    data, _ = image_utils.prepare_image_bytes(path, max_width=4000)
+    w, h = _dims(data)
+    assert (w, h) == (200, 400)  # transposed
+
+
+# --- Error handling -------------------------------------------------------
+
+
+def test_missing_file_raises_filenotfound(tmp_path):
+    missing = os.path.join(tmp_path, "does-not-exist.png")
+    with pytest.raises(FileNotFoundError):
+        image_utils.prepare_image_bytes(missing)
+
+
+def test_non_image_raises_runtimeerror(tmp_path):
+    path = os.path.join(tmp_path, "fake.png")
+    with open(path, "w") as f:
+        f.write("this is not an image")
+    with pytest.raises(RuntimeError):
+        image_utils.prepare_image_bytes(path)

--- a/skills/image-vision/vision-analyze-robust.sh
+++ b/skills/image-vision/vision-analyze-robust.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
-# Robust vision analysis with auto-fallback and timeout handling
+# Robust vision analysis with auto-fallback, bounded timeouts, and honest,
+# classified failures.
+#
 # Usage: ./vision-analyze-robust.sh <image_path> <prompt> [timeout_seconds]
 # Example: ./vision-analyze-robust.sh screenshot.png "Describe this UI" 60
+#
+# Exit codes (so callers can distinguish failure modes instead of guessing):
+#   0  success
+#   1  usage error, or all configured providers failed for mixed/other reasons
+#   3  no vision provider configured (no API key present) -- fail fast & clear,
+#      never hang waiting on a provider that can't run
+#   4  provider_timeout: provider(s) were configured but every attempt timed out
+#      within the bounded ${TIMEOUT}s -- distinct from "no provider" so a slow
+#      provider is not mislabeled as a missing one
 
 set -e
 
@@ -9,7 +20,7 @@ SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VENV_DIR="$SKILL_DIR/.venv"
 IMAGE_PATH="$1"
 PROMPT="$2"
-TIMEOUT="${3:-60}"  # Default 60s timeout
+TIMEOUT="${3:-60}"  # Default 60s timeout (bounded -- never an unbounded wait)
 
 # Validate arguments
 if [ -z "$IMAGE_PATH" ] || [ -z "$PROMPT" ]; then
@@ -20,22 +31,63 @@ if [ -z "$IMAGE_PATH" ] || [ -z "$PROMPT" ]; then
     exit 1
 fi
 
-# Ensure venv exists
+# Portable timeout: GNU coreutils 'timeout' (Linux) or 'gtimeout' (macOS via
+# `brew install coreutils`). If neither exists we still run, but cannot enforce
+# the bound -- say so loudly rather than pretend.
+TIMEOUT_BIN=""
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="gtimeout"
+else
+    echo "WARNING: no 'timeout' command found; provider calls will NOT be" >&2
+    echo "time-bounded. Install GNU coreutils (e.g. 'brew install coreutils')" >&2
+    echo "to enable the ${TIMEOUT}s timeout and provider_timeout classification." >&2
+fi
+
+# Ensure venv exists. Pillow is required: the provider scripts downscale and
+# bound the screenshot payload before sending (see examples/image_utils.py).
 if [ ! -d "$VENV_DIR" ]; then
     echo "First-time setup: Creating virtual environment..." >&2
     cd "$SKILL_DIR"
     uv venv
-    
-    echo "Installing vision SDKs (anthropic, openai, google-genai)..." >&2
-    uv pip install anthropic openai google-genai --quiet
-    
+
+    echo "Installing vision SDKs (anthropic, openai, google-genai) + pillow..." >&2
+    uv pip install anthropic openai google-genai pillow --quiet
+
     echo "✓ Setup complete!" >&2
     echo "" >&2
 fi
 
-# Try providers in order: Gemini (fastest) → Anthropic → OpenAI
-PROVIDERS=("gemini" "anthropic" "openai")
+# Make sure Pillow is present even if the venv predates this change.
+if ! "$VENV_DIR/bin/python" -c "import PIL" 2>/dev/null; then
+    echo "Installing pillow (required for screenshot downscaling)..." >&2
+    cd "$SKILL_DIR" && uv pip install pillow --quiet
+fi
+
+# Determine which providers are actually CONFIGURED (have an API key). We only
+# attempt configured providers -- trying one with no key just wastes a slot and
+# muddies the failure signal. Order: Gemini (fastest) -> Anthropic -> OpenAI ->
+# Azure (enterprise; needs both key and endpoint).
+PROVIDERS=()
+[ -n "$GOOGLE_API_KEY" ] && PROVIDERS+=("gemini")
+[ -n "$ANTHROPIC_API_KEY" ] && PROVIDERS+=("anthropic")
+[ -n "$OPENAI_API_KEY" ] && PROVIDERS+=("openai")
+[ -n "$AZURE_OPENAI_API_KEY" ] && [ -n "$AZURE_OPENAI_ENDPOINT" ] && PROVIDERS+=("azure")
+
+# Fail-fast, clear, actionable signal when NO provider is configured. This is
+# the failure that previously surfaced minutes later as an opaque hang.
+if [ ${#PROVIDERS[@]} -eq 0 ]; then
+    echo "ERROR: No vision provider configured." >&2
+    echo "Set one of: GOOGLE_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY," >&2
+    echo "or AZURE_OPENAI_API_KEY (+ AZURE_OPENAI_ENDPOINT)." >&2
+    echo "Vision screenshot analysis cannot run without a provider key." >&2
+    exit 3
+fi
+
 ERROR_LOG=$(mktemp)
+ATTEMPTED=0
+TIMEOUTS=0
 
 for PROVIDER in "${PROVIDERS[@]}"; do
     case "$PROVIDER" in
@@ -54,37 +106,60 @@ for PROVIDER in "${PROVIDERS[@]}"; do
             SDK_CHECK="import openai"
             SDK_INSTALL="openai"
             ;;
+        azure)
+            SCRIPT="azure-vision.py"
+            SDK_CHECK="import openai"
+            SDK_INSTALL="openai"
+            ;;
     esac
-    
+
     # Check/install SDK
     if ! "$VENV_DIR/bin/python" -c "$SDK_CHECK" 2>/dev/null; then
         echo "Installing $SDK_INSTALL SDK..." >&2
         cd "$SKILL_DIR" && uv pip install "$SDK_INSTALL" --quiet
     fi
-    
+
     echo "Trying $PROVIDER (timeout: ${TIMEOUT}s)..." >&2
-    
-    # Run with timeout
-    if timeout "$TIMEOUT" "$VENV_DIR/bin/python" "$SKILL_DIR/examples/$SCRIPT" "$IMAGE_PATH" "$PROMPT" 2>"$ERROR_LOG"; then
+    ATTEMPTED=$((ATTEMPTED + 1))
+
+    # Run with a bounded timeout when available.
+    set +e
+    if [ -n "$TIMEOUT_BIN" ]; then
+        "$TIMEOUT_BIN" "$TIMEOUT" "$VENV_DIR/bin/python" "$SKILL_DIR/examples/$SCRIPT" "$IMAGE_PATH" "$PROMPT" 2>"$ERROR_LOG"
+    else
+        "$VENV_DIR/bin/python" "$SKILL_DIR/examples/$SCRIPT" "$IMAGE_PATH" "$PROMPT" 2>"$ERROR_LOG"
+    fi
+    EXIT_CODE=$?
+    set -e
+
+    if [ $EXIT_CODE -eq 0 ]; then
         echo "✓ Success with $PROVIDER" >&2
         rm -f "$ERROR_LOG"
         exit 0
+    elif [ $EXIT_CODE -eq 124 ]; then
+        echo "✗ $PROVIDER timed out after ${TIMEOUT}s" >&2
+        TIMEOUTS=$((TIMEOUTS + 1))
     else
-        EXIT_CODE=$?
-        if [ $EXIT_CODE -eq 124 ]; then
-            echo "✗ $PROVIDER timed out after ${TIMEOUT}s" >&2
-        else
-            ERROR_MSG=$(cat "$ERROR_LOG" | head -5)
-            echo "✗ $PROVIDER failed (exit $EXIT_CODE):" >&2
-            echo "$ERROR_MSG" >&2
-        fi
-        # Try next provider
+        ERROR_MSG=$(cat "$ERROR_LOG" | head -5)
+        echo "✗ $PROVIDER failed (exit $EXIT_CODE):" >&2
+        echo "$ERROR_MSG" >&2
     fi
+    # Try next provider
 done
 
-# All providers failed
+# All configured providers failed. Classify the failure so the caller gets an
+# honest signal rather than a catch-all.
 echo "" >&2
-echo "ERROR: All vision providers failed" >&2
+if [ "$TIMEOUTS" -eq "$ATTEMPTED" ]; then
+    # Every attempt timed out: provider(s) present but too slow.
+    echo "ERROR: provider_timeout -- all ${ATTEMPTED} configured vision provider(s) timed out after ${TIMEOUT}s each." >&2
+    echo "Providers tried: ${PROVIDERS[*]}" >&2
+    echo "Try a larger timeout (3rd arg), a smaller image, or a faster provider." >&2
+    rm -f "$ERROR_LOG"
+    exit 4
+fi
+
+echo "ERROR: All configured vision providers failed" >&2
 echo "Providers tried: ${PROVIDERS[*]}" >&2
 echo "Last error:" >&2
 cat "$ERROR_LOG" >&2

--- a/skills/image-vision/vision-analyze.sh
+++ b/skills/image-vision/vision-analyze.sh
@@ -21,23 +21,34 @@ if [ -z "$IMAGE_PATH" ] || [ -z "$PROMPT" ]; then
     exit 1
 fi
 
-# Check if venv exists, create if not
+# Check if venv exists, create if not. Pillow is required: the provider scripts
+# downscale and bound the screenshot payload before sending (see
+# examples/image_utils.py).
 if [ ! -d "$VENV_DIR" ]; then
     echo "First-time setup: Creating virtual environment..." >&2
     cd "$SKILL_DIR"
     uv venv
     
-    echo "Installing vision SDKs (anthropic, openai, google-genai)..." >&2
-    uv pip install anthropic openai google-genai --quiet
+    echo "Installing vision SDKs (anthropic, openai, google-genai) + pillow..." >&2
+    uv pip install anthropic openai google-genai pillow --quiet
     
     echo "✓ Setup complete!" >&2
     echo "" >&2
 fi
 
-# Map provider to script and verify SDK installed
+# Make sure Pillow is present even if the venv predates this change.
+if ! "$VENV_DIR/bin/python" -c "import PIL" 2>/dev/null; then
+    echo "Installing pillow (required for screenshot downscaling)..." >&2
+    cd "$SKILL_DIR" && uv pip install pillow --quiet
+fi
+
+# Map provider to script, verify SDK installed, and check the provider's API key
+# is present. A missing key fails fast and clearly (exit 3) instead of surfacing
+# later as an opaque error.
 case "$PROVIDER" in
     anthropic)
         SCRIPT="anthropic-vision.py"
+        KEY_VAR="ANTHROPIC_API_KEY"; KEY_VAL="$ANTHROPIC_API_KEY"
         if ! "$VENV_DIR/bin/python" -c "import anthropic" 2>/dev/null; then
             echo "Installing anthropic SDK..." >&2
             cd "$SKILL_DIR" && uv pip install anthropic --quiet
@@ -45,6 +56,7 @@ case "$PROVIDER" in
         ;;
     openai)
         SCRIPT="openai-vision.py"
+        KEY_VAR="OPENAI_API_KEY"; KEY_VAL="$OPENAI_API_KEY"
         if ! "$VENV_DIR/bin/python" -c "import openai" 2>/dev/null; then
             echo "Installing openai SDK..." >&2
             cd "$SKILL_DIR" && uv pip install openai --quiet
@@ -52,6 +64,7 @@ case "$PROVIDER" in
         ;;
     gemini)
         SCRIPT="gemini-vision.py"
+        KEY_VAR="GOOGLE_API_KEY"; KEY_VAL="$GOOGLE_API_KEY"
         if ! "$VENV_DIR/bin/python" -c "from google import genai" 2>/dev/null; then
             echo "Installing google-genai SDK..." >&2
             cd "$SKILL_DIR" && uv pip install google-genai --quiet
@@ -59,6 +72,7 @@ case "$PROVIDER" in
         ;;
     azure)
         SCRIPT="azure-vision.py"
+        KEY_VAR="AZURE_OPENAI_API_KEY"; KEY_VAL="$AZURE_OPENAI_API_KEY"
         if ! "$VENV_DIR/bin/python" -c "import openai" 2>/dev/null; then
             echo "Installing openai SDK (for Azure)..." >&2
             cd "$SKILL_DIR" && uv pip install openai --quiet
@@ -70,6 +84,12 @@ case "$PROVIDER" in
         exit 1
         ;;
 esac
+
+if [ -z "$KEY_VAL" ]; then
+    echo "ERROR: No API key for provider '$PROVIDER' ($KEY_VAR is not set)." >&2
+    echo "Set $KEY_VAR, or use a provider whose key is configured." >&2
+    exit 3
+fi
 
 # Run the vision script with venv Python
 exec "$VENV_DIR/bin/python" "$SKILL_DIR/examples/$SCRIPT" "$IMAGE_PATH" "$PROMPT"


### PR DESCRIPTION
## Why (the issue we saw)

On reality-check run `resolve-97591b9133ac`, the browser journeys ran and passed, but the **vision verification step hung for ~62 minutes and never wrote `report.yaml`** — the run was then mislabeled as a config failure. The captured root cause: the dedicated vision path was unavailable (only `ANTHROPIC_API_KEY` was set in that container), and an **un-capped full-page PNG screenshot** was base64-encoded verbatim and sent in a large, slow, **interruptible** multimodal request that timed out across all retries and hung. A healthy run (`ae3ed6c31f56`) used the vision path cleanly with 0 retries.

This PR is **defense-in-depth, not the trigger fix.** The trigger (missing vision key in the backend env) was already removed operationally. This PR removes the *underlying fragility* in the `image-vision` skill and makes the failure **loud and fast** instead of a silent multi-minute hang.

## The code defect (substantiated)

All four provider scripts read the screenshot and base64-encoded it **verbatim, with no resize**, even though the skill's own docs advise "resize to 2000px max" (`SKILL.md`) and `patterns.md` ships an unused `preprocess_image` helper:

- `examples/anthropic-vision.py` (pre-PR L43), and the identical pattern in `openai-vision.py`, `azure-vision.py`, `gemini-vision.py`.

There was **no** dimension or payload cap anywhere on the path, and `vision-analyze-robust.sh` surfaced "All vision providers failed" as a generic `exit 1` with no way to tell "no provider configured" from "provider timed out."

## What this PR changes

**1. Automatic, conservative screenshot capping** — new `examples/image_utils.py` (`prepare_image_bytes` / `prepare_image_base64`), now called by all four provider scripts:
- Caps **width** to 2000px (downscale-only, never upscales; aspect preserved; LANCZOS; EXIF-aware). It caps **width, not the longest edge**, specifically so a tall full-page capture is **not squashed** — width is the dimension text legibility depends on.
- Enforces a **real, fail-closed payload bound** (4 MB base64, conservative vs Anthropic's 5 MB limit): shrink width to a 1024px legibility floor, then re-encode to JPEG at descending quality, and if it *still* cannot fit, **raise a clear error** rather than send an oversized payload.
- Normalizes CMYK/alpha for JPEG; Pillow is a hard dependency (fails loud with an install hint rather than silently sending an un-capped image).

**2. Fail clearly instead of hanging** — `vision-analyze-robust.sh`:
- Only attempts providers whose API key is present; **fails fast with exit `3` ("no vision provider configured")** instead of an opaque late failure.
- Classifies all-timeout exhaustion as exit `4` ("provider_timeout") — distinct from "no provider" so a slow provider isn't mislabeled as a missing one.
- Portable timeout (`timeout`/`gtimeout`, warns if neither); adds Azure to the fallback. `vision-analyze.sh` gains a per-provider key precheck (exit `3`).

**3. Docs** — `SKILL.md`/`setup.md` document the automatic cap, the exit-code contract, the capture-hygiene trade-off, and add `pillow` to install instructions.

## Verified vs proposed

**Verified (unit tests, no network — `tests/test_image_utils.py`, 14 passing):** width cap; no-upscale; aspect ratio; exactly-at-cap; **tall 1280x8000 keeps width** (not squashed); payload ceiling forces downscale; **JPEG rescue keeps payload under the bound**; **fail-closed raise** when incompressible; JPEG media type; CMYK→RGB; base64 roundtrip; EXIF orientation; missing-file and corrupt-file errors. `bash -n` clean on both scripts; all provider scripts `py_compile` clean.

**Not verified without the live stack:** the end-to-end 62-min reproduction, and the exact component that stacked multiple screenshots into one request. That stacking is a **separate harness-level concern** (how a vision agent's screenshots are attached to a single model turn) and is out of scope for this skill-level PR; it is under separate investigation. This PR removes the per-image payload fragility and the silent-hang failure mode regardless of that mechanism.

## Dual adversarial review (gate before this PR)

Both reviewers initially returned **FIX-FIRST**, reproduced real defects, and after the fixes both returned **SHIP**:

- **Crusty-old-engineer:** caught that the first cut capped the *longest edge* (squashing tall pages), used deprecated `Image.LANCZOS`, and that the manual-setup docs didn't install Pillow / named the deprecated `google-generativeai` SDK. All resolved (width-based cap; `Image.Resampling.LANCZOS`; docs fixed). Final: **SHIP.**
- **GPT-5.5 (adversarial):** independently reproduced (a) the tall-page squash 1280x8000→320x2000, (b) that the "4 MB cap" wasn't actually a cap (warned then sent oversized), (c) macOS missing `timeout` crashing the script, (d) Azure silently excluded from the robust path. All resolved (width cap; fail-closed JPEG-rescue/raise; portable timeout; Azure added). Re-ran the suite: 14 passed. Final: **SHIP.**

## Known/accepted (documented, non-blocking)
- Animated GIF: only the first frame is analyzed (vision sends one still anyway) — noted in `SKILL.md`.
- The 4 MB bound is tuned to the tightest provider (Anthropic); conservative for OpenAI/Gemini.
- For text-critical verification, prefer viewport-sized captures over aggressive full-page captures (the cap removes a hang risk; it does not make vision reliable for sub-pixel typography).

**Suggested, draft — for the bundle owner to review; do not merge on my behalf.**
