### PR TITLE
feat(skills): add amplifier-tool-leverage-patterns pattern skill

### DIFF
--- a/skills/amplifier-tool-leverage-patterns/SKILL.md
+++ b/skills/amplifier-tool-leverage-patterns/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: amplifier-tool-leverage-patterns
+description: >
+  Use when building an Amplifier-powered workflow or automation tool and
+  deciding how to expose it — as standalone .dot attractor pipelines (incl.
+  inside the Resolve dot-graph resolver), an importable Python lib, agent-callable
+  tool modules, or a CLI. Covers the four leverage levels, the DRY rule that keeps
+  logic in ONE home, and the judgment for which levels a real consumer actually
+  needs (and when adding a level is just ceremony).
+---
+
+# Amplifier Tool Leverage Levels
+
+## The Pattern
+
+**Problem:** You've built a workflow/automation tool on Amplifier. Different consumers want to use it different ways — an attractor pipeline wants to compose it, a web app wants to import it, an agent wants to call it as a tool, a human wants a CLI. You don't want four copies of the logic.
+
+**Approach:** Pick ONE home for the logic, then expose up to **four leverage levels** as *thin adapters* over that home. Build only the levels a real consumer demands.
+
+| Level | Surface | Consumer | What it is |
+|-------|---------|----------|------------|
+| **L1** | `.dot` attractor pipelines | Other pipelines / Resolve | One `.dot` per command + a shared subgraph (folder-shape), run on the loop-pipeline engine (`amplifier-bundle-attractor`) |
+| **L2** | Python lib | Other codebases | Each command an importable method; clean public API in `__init__.py` |
+| **L3** | Amplifier tool modules | Agents | `bundle.md` + `modules/tool-<name>/` wrapping each command as an agent-callable tool |
+| **L4** | CLI | Humans / scripts | Thin click/argparse wrapper over the lib |
+
+## The four levels, concretely
+
+**L1 — Standalone `.dot` attractor pipelines.** One `.dot` per command, plus a shared subgraph factored out via a `folder`-shape node. Runs on the loop-pipeline engine anywhere — **including inside the Amplifier Resolve dot-graph resolver**: register a `<name>.dot` + `<name>.resolver.yaml` in the resolver's `pipelines/` dir. Inside the graph, `parallelogram` nodes shell out to the tool's CLI (deterministic steps); `box` nodes are full LLM agents (synthesis steps). This is the level that lets your tool *compose into larger attractor flows*.
+
+**L2 — Python lib.** Each command is an importable method. Export a deliberate public API from `__init__.py`. This is what lets another codebase embed the tool directly — e.g. a web app importing it rather than shelling out.
+
+**L3 — Amplifier tool modules.** A `bundle.md` plus `modules/tool-<name>/` exposing each command as an agent-callable tool. Obey the `mount()` Iron Law; keep each tool a thin wrapper over the lib (run blocking work via `asyncio.to_thread`). This is what lets an agent call your tool as a tool.
+
+**L4 — CLI.** A thin click/argparse surface over the lib. Almost always worth it — it's the cheapest level and it's what L1's `parallelogram` nodes shell out to.
+
+## The DRY rule (load-bearing)
+
+The logic lives in **ONE place**; every level is a thin adapter over it. Where "one place" is depends on the nature of the work:
+
+- **LLM-logic tools** → the home is the **`.dot` files**. The prompts and graph *are* the logic. L2/L3/L4 orchestrate runs of those graphs.
+- **Deterministic tools** (e.g. git plumbing) → the home is the **lib**. The `.dot` files are *thin orchestration that shells out to the CLI/lib*.
+
+Two failure modes to refuse:
+
+1. **Don't re-implement logic in the `.dot`.** If the core is deterministic, the `.dot` calls it — it does not reproduce it.
+2. **Don't fold a dependency's private engine into your `.dot`.** Keep dependencies behind their public CLI/subprocess boundary. Low coupling beats a fast path that reaches into someone else's internals.
+
+## The judgment: which levels do I actually need?
+
+**Do NOT build all four by default.** Build the level a *real consumer* demands:
+
+| Build... | When a real consumer needs... |
+|----------|-------------------------------|
+| **L1** | Resolve / attractor composition |
+| **L2** | an app that will `import` it |
+| **L3** | an agent that will call it as a tool |
+| **L4** | almost always (cheapest; L1 shells out to it) |
+
+Building a level "to complete the set" is over-engineering. **Prove each level with a real consumer:** L1 is proven by being *registered and RUN* in the resolver; L2 by an actual import; L3 by an agent invocation. A level that is never run by its consumer is ceremony — delete it or don't build it yet.
+
+## When this pattern is the WRONG answer
+
+- **A plain library or CLI does the job and nothing composes/embeds/agent-calls it** → just ship L4 (and maybe L2). Don't reach for attractor pipelines or tool modules to "be thorough." See `cli-packaging-patterns`.
+- **The tool isn't Amplifier/LLM-powered at all** → the leverage levels add an Amplifier dependency for no gain. Use ordinary packaging.
+- **You can't name the consumer for a level** → that's the signal not to build it. Levels follow demand, not symmetry.
+
+## Worked exemplar: repo-weaver
+
+[`repo-weaver`](https://github.com/bkrabach/amplifier-bundle-repo-weaver) demonstrates all four levels, **each proven**:
+
+- **L1** — its `.dot` pipeline ran end-to-end in the Resolve dot-graph resolver inside a DTU.
+- **L2** — exports a public API for direct import.
+- **L3** — ships `tool-repo-weaver` (3 tools), proven to return real cited output.
+- **L4** — its CLI ran across 30 repos.
+
+Its **deterministic git→docs core lives in the lib**; the LLM synthesis is delegated to the external `wiki-weaver` engine **via subprocess** (`dependencies = []`, crossed only at the process boundary) — the public-boundary, low-coupling choice the DRY rule above prescribes. Read its `ARCHITECTURE.md` for the boundary in detail.
+
+## Future levels (extensions, not part of the core four)
+
+MCP/REST service wrappers and self-hosted web UIs are natural further leverage levels over the same lib. Add them when a consumer needs them — same rule: prove the consumer first.
+
+## Related skills
+
+- **`cli-packaging-patterns`** — how to build L4 (and the L2 packaging) cleanly.
+- **`plugin-discovery-patterns`** — entry-point discovery for L3 tool modules and resolver pipelines.
+- **`creating-amplifier-modules`** — the `mount()` Iron Law and module structure for L3.
+- **`dot-patterns`** / **`dot-syntax`** — authoring the L1 `.dot` graphs (folder-shape subgraphs, `parallelogram` vs `box` nodes).


### PR DESCRIPTION
## Summary

Adds a new pattern-library skill — `amplifier-tool-leverage-patterns` — capturing the **four leverage levels** pattern for building and exposing Amplifier-powered workflow/automation tools.

### What the skill covers

The skill addresses a common design question: *you've built a workflow tool on Amplifier — how do you expose it so pipelines, apps, agents, and humans can all use it without duplicating logic?*

It documents four leverage levels as **thin adapters over a single logic home**:

| Level | Surface | Consumer |
|-------|---------|----------|
| **L1** |  attractor pipelines (incl. Resolve dot-graph resolver) | Other pipelines / Resolve |
| **L2** | Python lib | Apps that import it |
| **L3** | Amplifier tool modules | Agents |
| **L4** | CLI | Humans / scripts |

Key principles:
- **DRY rule** — logic lives in ONE place; which place depends on whether the tool is LLM-logic-first (home = ) or deterministic-first (home = lib)
- **Demand-driven level selection** — prove each level with a real consumer before building it; a level no consumer runs is ceremony
- **When this is the wrong answer** — plain tools that nothing composes should skip to L4 (see )

### Worked exemplar: repo-weaver

[](https://github.com/bkrabach/amplifier-bundle-repo-weaver) demonstrates all four levels, each **proven**:

- **L1** — its  pipeline ran end-to-end in the Resolve dot-graph resolver inside a DTU ✓
- **L2** — exports a public API for direct import ✓
- **L3** — ships  (3 tools), proven to return real cited output ✓
- **L4** — its CLI ran across 30 repos ✓

Its deterministic git→docs core lives in the lib; LLM synthesis is delegated to the external usage: wiki-weaver [-h] [--version] {init,ingest,lint,doctor,query,ask} ...

LLM-wiki ingest pipeline driven by the attractor engine.

positional arguments:
  {init,ingest,lint,doctor,query,ask}
    init                scaffold a wiki directory and design its schema
    ingest              integrate inbox sources via the engine
    lint                run the structural validator
    doctor              environment diagnostics
    query               naive substring page search; for real cited answers
                        use 'ask'
    ask                 answer a question by reading the compiled wiki (no
                        embeddings)

options:
  -h, --help            show this help message and exit
  --version             show program's version number and exit engine **via subprocess** (the low-coupling, public-boundary choice the DRY rule prescribes).

### Related skills (pattern-library family)

- **`cli-packaging-patterns`** — how to build L4 (and L2 packaging) cleanly
- **`plugin-discovery-patterns`** — entry-point discovery for L3 tool modules and resolver pipelines
- **`creating-amplifier-modules`** — the `mount()` Iron Law and module structure for L3
- **`dot-patterns`** / **`dot-syntax`** — authoring the L1 `.dot` graphs

---
Generated with [Amplifier](https://github.com/microsoft/amplifier)