### PR TITLE
chore(skills): point amplifier-tool-leverage-patterns exemplar at microsoft/amplifier-app-repo-weaver

### DIFF
--- a/skills/amplifier-tool-leverage-patterns/SKILL.md
+++ b/skills/amplifier-tool-leverage-patterns/SKILL.md
@@ -67,7 +67,7 @@ Building a level "to complete the set" is over-engineering. **Prove each level w
 
 ## Worked exemplar: repo-weaver
 
-[`repo-weaver`](https://github.com/bkrabach/amplifier-bundle-repo-weaver) demonstrates all four levels, **each proven**:
+[`repo-weaver`](https://github.com/microsoft/amplifier-app-repo-weaver) demonstrates all four levels, **each proven**:
 
 - **L1** — its `.dot` pipeline ran end-to-end in the Resolve dot-graph resolver inside a DTU.
 - **L2** — exports a public API for direct import.


### PR DESCRIPTION
## Summary

- Replace stale exemplar link `bkrabach/amplifier-bundle-repo-weaver` → `microsoft/amplifier-app-repo-weaver` in `skills/amplifier-tool-leverage-patterns/SKILL.md`
- One-line change, no logic modified. CLI/tool name `repo-weaver` and `wiki-weaver` references are untouched.
- The target repo migrated from the personal fork to the Microsoft org; this corrects the broken link.

## Test plan
- [x] `grep -n 'bkrabach/amplifier-bundle-repo-weaver' SKILL.md` → zero hits
- [x] `grep -n 'amplifier-app-repo-weaver' SKILL.md` → 1 hit (line 70, exemplar link)
- [x] `repo-weaver` tool name unchanged — confirmed in grep output
- [x] N/A — no code logic, tests, or functional behaviour affected

Generated with [Amplifier](https://github.com/microsoft/amplifier)