### PR TITLE
fix: council-here — fan lenses out directly, not via worker

### DIFF
--- a/skills/council-here/SKILL.md
+++ b/skills/council-here/SKILL.md
@@ -43,27 +43,23 @@ tradeoffs** made, and any **constraints**. Be **faithful and neutral** — captu
 was decided and *why*, **not** your own opinion of it. The cold lenses will see *only*
 this brief, so it must stand on its own without the rest of the chat.
 
-## Phase 1 — Convene (lean + cold)
+## Phase 1 — Convene (cold + independent)
 
-To keep this session's context lean **and** the lenses cold/independent, run the panel
-inside a delegated worker rather than fanning out inline:
+You are running **inline** in this session, so **you** have the `delegate` tool — fan the
+lenses out **directly from here.** Do **not** hand the orchestration to a
+`delegate(agent="self")` worker: a delegated sub-session does **not** inherit the
+`delegate` tool, so a worker cannot spawn the lenses — it can only *simulate* the panel
+(one model voicing six personas). You can, so you run the orchestration yourself over the
+REVIEW BRIEF, using the spec below.
 
-```
-delegate(
-  agent="self",
-  context_depth="none",
-  instruction = <the REVIEW BRIEF> + "\n\n" + <the Orchestration Spec below>
-)
-```
-
-The worker runs the full council over the brief and returns **only** the roster
-manifest + synthesized verdict. Relay that to the user verbatim (it is the work
-product). This mirrors `/council`'s context-isolation benefit while still being seeded
-with the local context the fork could never see.
+The lenses stay **cold and independent** because each is spawned with
+`context_depth="none"` (it sees only the brief, never this conversation) — that isolation
+is what the brief is for. Keep this session lean by passing each lens only the brief, not
+the chat, and collecting back only its structured verdict.
 
 ---
 
-## Orchestration Spec — hand this (with the brief) to the worker
+## Orchestration Spec — run this yourself over the REVIEW BRIEF
 
 > Keep in sync with `council/SKILL.md` Phases 1–5. The TARGET is the REVIEW BRIEF above.
 


### PR DESCRIPTION
## Summary

council-here is the inline counterpart to /council. Its lenses were SIMULATED: it handed the six-lens fan-out to a `delegate(agent="self")` worker, but a delegate-spawned sub-session does NOT inherit the `delegate` tool (the platform strips tool-delegate from children to prevent recursion), so the worker could not spawn the lenses — it loaded all six personas and voiced them in ONE session.

The fix is a **MINIMAL change to the author's original** (only the Phase-1 hop, +12/−16 lines, the rest of the author's body untouched): since council-here runs INLINE it already HAS the delegate tool, so it now fans the six lenses out DIRECTLY itself, each as a cold `delegate(context_depth="none")` sub-session seeded with the review brief. No worker, no fork, no dependency on /council.

Companion to PR#31 (which fixed the /council fork's allowed-tools); this fixes the remaining council-here simulation that #31's allowed-tools removal could not (the field was inert for an inline skill).

## Evidence (from DTU-based evals-driven development)

All grading from session **events.jsonl** (not json-trace's unreliable total_agents_invoked counter, which reads 0 even when working).

### Certified N=3 before/after

| Scenario | V_base (worker, current main) | V_fix (Option A, this PR) |
|----------|------|------|
| **S2: /council-here** | 3/3 SIMULATED: delegate_spawned=0, child_sessions=0 | 3/3 REAL: 6 cold fan-out delegations, 6 child lens sessions, grounded in brief |
| **S1: /council <file>** | 3/3 REAL (regression guard) | 3/3 REAL (sha-identical council/SKILL.md) |
| **S3: /council <idea>** | 3/3 REAL (regression guard) | 3/3 REAL (sha-identical council/SKILL.md) |

### Lens independence proven
- Pairwise output similarity: **0.12–0.20** (single model voicing six would be ~0.9+)
- Lenses returned **different verdicts** on same brief: cranky-old-sam CONCERN vs others FAIL — proof of six distinct minds, not ventriloquism

### Zero fabricated tool calls
- No fabricated tool_call text in any session of any trial
- **Notable:** the simulated baseline produced zero fake text and grounded-looking output — the bug is **SILENT**, visible only in events (agents_spawned=0/child_sessions=0); that's why we held N=3 rather than eyeballing output

### Honest caveat
- council-here now reviews a **distilled BRIEF** of the conversation (cold lenses see only the brief, by design, to stay independent)
- Remaining council-suggested follow-ups (more diverse targets, partial-delegation-failure scenario, user-facing signal that panel really convened) are eval/UX hardening, tracked separately, not blockers for this fix

Generated with [Amplifier](https://github.com/microsoft/amplifier)
