### PR TITLE
docs: surface /council→/council-here auto-route in usage

### DIFF
--- a/skills/council/SKILL.md
+++ b/skills/council/SKILL.md
@@ -54,6 +54,9 @@ the surrounding chat) → continue to Phase 1.
 Usage: /council <target>          (isolated review of an external target)
        /council-here [focus]      (review the CURRENT conversation / plan)
 
+Not sure which? You can't really pick wrong — point /council at the current
+conversation and it auto-routes to /council-here.
+
 A /council target can be:
   - an idea or design described in plain, self-contained text
   - a file path (a spec, design doc, or source file)


### PR DESCRIPTION
The shipped council/council-here descriptions are accurate; this just makes the existing auto-routing behavior (council's Guard Check already routes conversational references to council-here) discoverable in the /council usage block, so users don't agonize over which command to pick.

Backed by an N=6 DTU eval showing /council reliably auto-routes a conversational reference to council-here (grounded, zero fabrication).