### PR TITLE
fix: council-here — prevent context-elaboration-bleed in the review brief

### DIFF
--- a/skills/council-here/SKILL.md
+++ b/skills/council-here/SKILL.md
@@ -43,6 +43,22 @@ tradeoffs** made, and any **constraints**. Be **faithful and neutral** — captu
 was decided and *why*, **not** your own opinion of it. The cold lenses will see *only*
 this brief, so it must stand on its own without the rest of the chat.
 
+**Source discipline (critical).** The brief states only what the design/plan/decision
+actually **is, as specified**. Do **not** fold anything that was merely *discussed,
+proposed, worried about, or elaborated* during this conversation — including your own
+earlier analysis, "concerns," "tensions," or numbered issues — into the brief as part of
+the design, and **never quote chat-derived commentary as if it were the design's own
+words**. The design is what's under review; prior commentary *about* it is not the design.
+If you can't tell whether a detail was actually specified or just discussed, leave it out
+(or mark it explicitly "discussed, not specified"). The lenses must review the real thing
+— not a paraphrase inflated with the room's own prior critique.
+
+**No target, no panel (fail loud).** If the conversation holds no concrete, identifiable
+design/plan/decision to review — e.g. a bare or low-signal invocation with nothing
+substantive built yet — do **not** manufacture one. Say so plainly and ask what to review.
+Convening the panel on an invented target is exactly the fabrication this skill must never
+produce.
+
 ## Phase 1 — Convene (cold + independent)
 
 You are running **inline** in this session, so **you** have the `delegate` tool — fan the


### PR DESCRIPTION
## Summary

council-here builds a brief of the current conversation for the cold lenses. It was folding the in-session assistant's OWN prior elaboration — invented "concerns", numbered "tensions", a non-existent "Known Tensions section" — into that brief and the lenses then quoted it back as the user's design's own specification (fabrication). Worst on low-signal invocations.

## Fix

Adds two Phase-0 rules to skills/council-here/SKILL.md:

1. **SOURCE DISCIPLINE** — the brief states only what the design actually IS as specified; never fold prior chat discussion/concerns/elaboration into it or quote chat-derived commentary as the design's own words.
2. **FAIL LOUD** — if there is no concrete design to review, do not manufacture one; say so plainly and ask what to review.

## Validation

Tested in pinned-model DTUs, graded from events.jsonl:
- On a deterministic recreation (assistant invents 5 numbered concerns, then ), the lenses attributed **0/8** of those concerns to the design (was up to ~50%).
- Fail-loud fired **6/6** on a no-design conversation.
- A grounded-design control still convened cleanly **6/6** with no over-refusal (no regression).

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)