### PR TITLE
feat(council): add MJ as the 7th panel lens (worth & sense)

### DIFF
--- a/skills/council-here/SKILL.md
+++ b/skills/council-here/SKILL.md
@@ -10,7 +10,7 @@ model_role: critique
 
 You are the **concierge**, running **inline in the current session** — so unlike
 `/council` (which forks and runs isolated), **you can see this conversation and the
-work in progress.** Your job: convene the six review lenses on **what we are working
+work in progress.** Your job: convene the seven review lenses on **what we are working
 on right now**, and return a synthesized verdict with recorded dissent.
 
 ## Say this first — out loud, one line (non-negotiable)
@@ -65,7 +65,7 @@ You are running **inline** in this session, so **you** have the `delegate` tool 
 lenses out **directly from here.** Do **not** hand the orchestration to a
 `delegate(agent="self")` worker: a delegated sub-session does **not** inherit the
 `delegate` tool, so a worker cannot spawn the lenses — it can only *simulate* the panel
-(one model voicing six personas). You can, so you run the orchestration yourself over the
+(one model voicing seven personas). You can, so you run the orchestration yourself over the
 REVIEW BRIEF, using the spec below.
 
 The lenses stay **cold and independent** because each is spawned with
@@ -81,13 +81,14 @@ the chat, and collecting back only its structured verdict.
 
 ### Resolve the roster
 
-The **bench (v1) is exactly six personas.** **Mandatory core** (always included —
+The **bench (v2) is exactly seven personas.** **Mandatory core** (always included —
 never drop one):
 
 - **intent-keeper** — "Is the goal clear, consistent, and still the real goal?"
 - **cranky-old-sam** — "Why does this exist at all? What can be deleted?"
 - **crusty-old-engineer** — "What will this cost to run/own later?"
 - **restless-old-brian** — "Is it REAL, proven end-to-end, in the right order?"
+- **mj** — "We can — but should we? Does it make sense, and so what?"
 
 **Conditional lenses** (default-on; include unless clearly N/A — record the decision,
 included or excluded, with a one-line reason in the manifest):
@@ -97,12 +98,14 @@ included or excluded, with a one-line reason in the manifest):
 - **tester-breaker** — include when there's a runnable/testable artifact (a repo, a
   diff, executable code, or a concrete plan that can fail in operation).
 
-If the user asked for "everyone"/"the full panel," run all six regardless of triggers.
+If the user asked for "everyone"/"the full panel," run all seven regardless of triggers.
 
 > **Where each lens lives.** intent-keeper, cranky-old-sam, crusty-old-engineer,
-> user-advocate, tester-breaker are in **this** bundle. **restless-old-brian lives in
-> `microsoft-amplifier/amplifier-bundle-made-support`.** If that bundle isn't installed,
-> its skill won't load — handle via Graceful Degradation below.
+> user-advocate, tester-breaker are in **this** bundle. Two lenses live elsewhere:
+> **restless-old-brian** in `microsoft-amplifier/amplifier-bundle-made-support`, and
+> **mj** in `occams-machete` (`michaeljabbour/amplifier-bundle-occams-machete`). If
+> either bundle isn't installed, that skill won't load — handle via Graceful
+> Degradation below.
 
 ### Round 1 — cold, independent fan-out
 
@@ -155,7 +158,7 @@ tradeoff stated plainly for the human to resolve.
 
 ## Relationship to `/council`
 
-Same six lenses, same orthogonality, same trust guardrails — **only the target differs.**
+Same seven lenses, same orthogonality, same trust guardrails — **only the target differs.**
 `/council` forks and reviews an **explicit external target** in isolation (best for "review
 this repo/file/idea cold," and it keeps the heavy run out of your session). `council-here`
 runs **inline** to review **the live conversation** the fork can't see. If someone invokes

--- a/skills/council/SKILL.md
+++ b/skills/council/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: council
-description: "Convene the persona panel (six orthogonal review lenses) on a target — cold independent fan-out, debate-to-consensus, synthesized verdict with recorded dissent and a roster manifest."
+description: "Convene the persona panel (seven orthogonal review lenses) on a target — cold independent fan-out, debate-to-consensus, synthesized verdict with recorded dissent and a roster manifest."
 context: fork
 disable-model-invocation: true
 user-invocable: true
@@ -75,8 +75,8 @@ Examples:
 
 ## Phase 1: Resolve the Roster
 
-The **bench (v1) is exactly six personas** — no larger pool exists. "Bench" ==
-these six.
+The **bench (v2) is exactly seven personas** — no larger pool exists. "Bench" ==
+these seven.
 
 **Mandatory core** (always included — hard-coded, never drop one):
 
@@ -84,6 +84,7 @@ these six.
 - **cranky-old-sam** — "Why does this exist at all? What can be deleted?"
 - **crusty-old-engineer** — "What will this cost to run/own later?"
 - **restless-old-brian** — "Is it REAL, proven end-to-end, in the right order?"
+- **mj** — "We can — but should we? Does it make sense, and so what?"
 
 **Conditional lenses** (default-on; included **unless you judge them clearly
 N/A** for this target — record the decision, included **or** excluded, **with a
@@ -97,17 +98,18 @@ one-line reason** in the roster manifest):
   executable code.
 
 **`consult_everyone` bypass.** If the user asked for "everyone" or the "full
-panel," bypass the triggers and run all six regardless of task signal. Even when
+panel," bypass the triggers and run all seven regardless of task signal. Even when
 a conditional lens is excluded, the manifest must still record it as excluded
 **with the one-line reason** — exclusion is an auditable decision, not a silent
 drop.
 
 > **Where each lens lives.** intent-keeper, cranky-old-sam, crusty-old-engineer,
 > user-advocate, and tester-breaker are skills in **this** bundle (load by name).
-> **restless-old-brian currently lives in
-> `microsoft-amplifier/amplifier-bundle-made-support`, not this bundle.** If that
-> bundle is not installed, its skill will not load — see Graceful Degradation in
-> Phase 3.
+> Two lenses live in **other** bundles: **restless-old-brian** in
+> `microsoft-amplifier/amplifier-bundle-made-support`, and **mj** in the
+> `occams-machete` bundle (`michaeljabbour/amplifier-bundle-occams-machete`). If
+> either bundle is not installed, that lens's skill will not load — see Graceful
+> Degradation in Phase 3.
 
 ---
 


### PR DESCRIPTION
## What
Adds **`mj`** (the Michael Jabbour advisor-persona lens) as the **7th** member of the persona council, in the **mandatory core**. Updates both `skills/council/SKILL.md` and `skills/council-here/SKILL.md`: bench cap six→seven, the mandatory-core list, the "run all six/seven" bypass, and the "Where each lens lives" note.

## Why
`mj` owns a distinct axis none of the existing six cover — **"we can — but should we? does it make sense, and so what?"** (worth + first-principles soundness + significance). It was built with the `personafy` skill, grounded in verified writings, and proven to steer in fresh isolated sessions. Its collapse test cedes complexity→cranky-old-sam, proof→restless-old-brian, goal-fidelity→intent-keeper.

## Cross-bundle (no duplication)
`mj` lives in the **`occams-machete`** bundle (`michaeljabbour/amplifier-bundle-occams-machete`), NOT this bundle — exactly the pattern restless-old-brian already uses (it lives in `made-support`). Council convenes it by name via `load_skill` + **Graceful Degradation**: if `occams-machete` is not installed, council marks `mj` UNAVAILABLE with a reason and proceeds with the other six. No skill is copied or relocated; per amplifier-expert guidance the skill-bundle boundary is a privacy/ownership boundary, not a participation boundary (mj is modeled on a real person, so it stays in its owner's bundle rather than being published here).

## Scope
Intentionally minimal: only the two council roster files change. The fan-out already iterates "each rostered lens" generically, so it picks up the 7th automatically. The six sibling skills' "one lens among six" self-descriptions are deliberately left as a separate follow-up (cosmetic; does not affect function).