### PR TITLE
docs: extend amplifier-tool-leverage-patterns with attractor-only specialization

### DIFF
--- a/skills/amplifier-tool-leverage-patterns/SKILL.md
+++ b/skills/amplifier-tool-leverage-patterns/SKILL.md
@@ -5,8 +5,9 @@ description: >
   deciding how to expose it — as standalone .dot attractor pipelines (incl.
   inside the Resolve dot-graph resolver), an importable Python lib, agent-callable
   tool modules, or a CLI. Covers the four leverage levels, the DRY rule that keeps
-  logic in ONE home, and the judgment for which levels a real consumer actually
-  needs (and when adding a level is just ceremony).
+  logic in ONE home, the judgment for which levels a real consumer actually needs
+  (and when adding a level is just ceremony), and the maximally-DRY attractor-only
+  specialization where the .dot pipeline is the sole logic home.
 ---
 
 # Amplifier Tool Leverage Levels


### PR DESCRIPTION
## Summary

This PR extends the existing `amplifier-tool-leverage-patterns` skill with a new section documenting the **attractor-only specialization** — a target architectural pattern for Amplifier bundles where an attractor .dot pipeline is the sole home of all logic by construction.

## What This Adds

**New section:** `## Specialization: attractor-only bundles (target shape, not yet proven)`

This documents the ideal shape where a single .dot file drives:
  - Standalone .dot runnable in any attractor engine (zero Amplifier coupling)
  - Dot-graph resolver sidecar in Amplifier Resolve (DTU/Team Pulse hosted use)
  - Lite engine-wrapper lib usable by any Python project (zero Amplifier dependency)
  - Amplifier tool module (thin mount() wrapper)
  - Click-based CLI (thin wrapper)

All five consumption surfaces backed by that ONE .dot pipeline.

## Key Callouts

- **Explicitly names the anti-pattern to avoid:** .dot files requiring compile-time templating before an engine can run them — that's hidden coupling, not self-containment.
- **Flags this as target/aspirational:** Not yet proven end-to-end anywhere.
- **Real-world reference:** Cites `microsoft/amplifier-app-wiki-weaver` as the closest reference, but clearly notes where it still falls short:
  - .dot files are token-templated (not standalone)
  - Only 1 of 5 pipelines has a resolver sidecar
  - Engine wrapper still coupled to Amplifier's PreparedBundle (should be a lite standalone shim)
  - CLI is argparse, not Click (design doc says Click is the target)
- **Strong instruction:** Readers must not copy wiki-weaver's current coupling forward as if it were the pattern.

## Why Now

The pattern captures an emerging best practice for attractor-driven Amplifier bundles (dot-graph-resolver testability, multiple consumption modes, single logic home) before any bundle has fully implemented it end-to-end. This allows the pattern to be discovered and refined before the first real instance ships, and prevents future builders from inadvertently copying intermediate coupling states as if they were the canonical pattern.

Updated frontmatter description to include trigger phrasing for this specialization ('maximally-DRY attractor-only specialization where the .dot pipeline is the sole logic home').

## Verification

No automation or integration tests apply — this is skill authoring (documentation extension) with no executable deliverables. The section was reviewed against the pattern discovered in session #53920f11 and the current wiki-weaver implementation.
