### PR TITLE
Councilify meta-skill + verdict decision rule, description-length check

### DIFF
--- a/skills/councilify/SKILL.md
+++ b/skills/councilify/SKILL.md
@@ -81,45 +81,82 @@ design artifact.
 template from memory, and name why `council-here` is inline while `council`
 forks.
 
-### 2. Frame the domain and mine candidate lenses
+### 2. Derive the domain's ideal roster — BLIND to the existing inventory first
 
 Name the domain's **target class** (what artifact does this council review?) and
-**stage** (when in the lifecycle?). Then mine real domain-leadership archetypes
-for the distinct perspectives that domain demands. For each candidate: one
-load-bearing question, the archetype/framework it's grounded in, and a one-line
-voice.
+**stage** (when in the lifecycle?). Then derive, independently of what already
+exists, the distinct perspectives that domain genuinely demands — mining real
+domain-leadership archetypes for each. For each candidate: one load-bearing
+question, the archetype/framework it's grounded in, and a one-line voice.
+
+**Do this before looking at the installed skill inventory.** Naming what already
+exists first biases the derivation toward "what we have" instead of "what the
+domain actually needs" — the two can look similar, but a roster built the second
+way is more likely to contain the ideal makeup rather than a locally-convenient
+one.
 
 - **Execution:** Delegate parallel `model_role="research"` agents to gather
   archetype evidence per candidate lens; each writes findings to disk, returns a
-  thin summary.
+  thin summary. Explicitly instruct each research agent NOT to consult or let
+  its own visible skill list bias which perspectives it proposes — derive from
+  the domain's real leadership archetypes and literature, not from what
+  happens to already be installed.
+
+**Honest limitation, stated plainly (verified directly, not assumed):** on this
+platform, a `delegate`-spawned sub-session — even with `context_depth="none"` —
+still receives an unconditional `hooks-skills-visibility` system-reminder
+listing dozens of installed skill names, regardless of what it was told or
+asked to do. This was confirmed by direct test: a cold, context-free sub-agent
+reported seeing the full skill list before any instruction reached it. **True
+technical isolation from the inventory is not currently achievable via
+`delegate` alone on this platform.** Treat the "don't consult the inventory"
+instruction above as a *policy constraint you are asking the model to honor*,
+not an architectural guarantee — and say so if you rely on it. If a stronger
+guarantee is ever needed, that requires a different mechanism than same-platform
+`delegate` (e.g., an external process with no skill-visibility hook at all);
+don't claim isolation you haven't verified holds.
 
 **Success criteria:** A candidate list where each entry has ONE question grounded
-in a named archetype, not a vibe.
+in a named archetype, not a vibe — derived from the domain's real needs first.
 
-### 3. Additive test — inventory and route every candidate
+### 3. Reconcile against the installed inventory — route every candidate
 
-Enumerate the FULL installed inventory before building anything:
-`load_skill(list=true)` for all lens skills, and identify every existing panel —
-`council` (6: intent-keeper, cranky-old-sam, crusty-old-engineer,
-restless-old-brian, user-advocate, tester-breaker), `design-council` (7 design
-lenses), `adversarial-review` (6: SRE, security, staff engineer, finance,
-operator, developer advocate — production/operational risk of a system design;
-note it also ships a recipe-callable `systems-design-critic` agent form of the
-same bench, a third composition pattern worth considering in Step 6's optional
-extension), plus any others surfaced by the inventory scan.
+Only now enumerate the FULL installed inventory: `load_skill(list=true)` for all
+lens skills, and identify every existing panel — `council` (6: intent-keeper,
+cranky-old-sam, crusty-old-engineer, restless-old-brian, user-advocate,
+tester-breaker), `design-council` (7 design lenses), `adversarial-review` (6:
+SRE, security, staff engineer, finance, operator, developer advocate —
+production/operational risk of a system design; note it also ships a
+recipe-callable `systems-design-critic` agent form of the same bench, a third
+composition pattern worth considering in Step 6's optional extension), plus any
+others surfaced by the inventory scan.
 
-Build a **coverage matrix**: candidate lens × existing lenses. Route each
-candidate to exactly one of:
+Build a **coverage matrix**: the Step 2 candidate list × existing lenses. Route
+each candidate to exactly one of:
 - **REUSE** — an existing lens already owns this exact question → compose by
   reference; record its home bundle + graceful-degradation note.
 - **BUILD-skill** — a real, distinct review question with no owner → Step 5.
 - **BUILD-agent** — not a review lens at all but an *active builder/specialist*
   → Step 4.
 
+**Don't let reconciliation silently re-inflate what Step 2 derived as ideal.**
+If an existing lens is a near-but-imperfect match for a Step 2 candidate,
+check whether it's a genuine REUSE or whether accepting it is convenience
+posing as fit — a real mismatch is still a BUILD, even if something adjacent
+already exists.
+
 Then apply the **needs-its-own-council test** (all three required): distinct
 target class; ≥4–5 net-new orthogonal lenses; folding them into an existing bench
 would make it incoherent or oversized (>~8). If it fails, STOP and recommend
 `personafy`-ing the 1–2 new lenses into the existing council instead.
+
+**Don't fix the headcount before this step produces it.** Naming a target
+number ("we want N lenses") before deriving the roster is the same bias this
+step exists to prevent, aimed at a different constraint — the count is an
+output of Steps 2–3, not an input to them. If real evidence (multiple
+independent derivations, actual usage history, a genuine overlap check) later
+argues for a different count than what a single pass produced, that's a reason
+to re-derive, not to trim or pad toward a number decided in advance.
 
 #### Bench-size guidance (a strong default, not a gate)
 

--- a/skills/councilify/SKILL.md
+++ b/skills/councilify/SKILL.md
@@ -121,6 +121,56 @@ target class; ≥4–5 net-new orthogonal lenses; folding them into an existing 
 would make it incoherent or oversized (>~8). If it fails, STOP and recommend
 `personafy`-ing the 1–2 new lenses into the existing council instead.
 
+#### Bench-size guidance (a strong default, not a gate)
+
+Grounded in the real benches confirmed in this ecosystem, not invented round
+numbers: `council` runs exactly 6 (intent-keeper, cranky-old-sam,
+crusty-old-engineer, restless-old-brian, user-advocate, tester-breaker) —
+confirmed directly from its own `SKILL.md`. `adversarial-review` runs exactly
+6 (SRE, security, staff engineer, finance, operator, developer advocate) —
+confirmed via its own declared skill description, surfaced live in-session (its
+source file was not available to inspect directly, so this is a
+metadata-level confirmation, not a file-level one — say so if you're ever in
+the same position). `design-council` runs exactly 7 — confirmed directly from
+its own `SKILL.md`. A `product-council` instance in this ecosystem grew from 7
+to 8 after a genuinely orthogonal 8th lens passed the collapse-test gate
+against its single closest neighbor — confirmed directly from its own
+`SKILL.md` and bundle.md, which both flag 8 explicitly as "the edge, not the
+comfortable middle" of the range below.
+
+From these four real data points — **6, 6, 7, 8** — treat as a strong default:
+
+- **Hard floor ~4.** Below four lenses, you don't have enough irreducible
+  perspectives to justify calling the thing a "council" rather than just
+  adding a couple of extra reviewers to whatever bench already exists — the
+  orchestration overhead (roster manifest, cold fan-out, debate-to-consensus
+  machinery) stops paying for itself. No confirmed bench in this ecosystem
+  runs below 6; treat 4 as the line below which you should stop and ask
+  whether this needs the council mechanism at all, not just a smaller one.
+- **Typical/comfortable range 5–7.** Brackets all three of the smaller
+  confirmed working benches (6, 6, 7) — the load a synthesizer can hold in
+  its head, attribute every claim to, and quote verbatim from, per lens,
+  without the Phase-5/Phase-4 synthesis guardrails becoming unwieldy.
+- **Soft ceiling ~8.** `design-council`'s 7 is the largest *comfortable*
+  confirmed precedent; the one 8-lens bench on record explicitly flags
+  itself as sitting at the edge of the range, not inside it. Above 8, the
+  cost of full cold fan-out (every lens spawned in an isolated sub-session)
+  and the cognitive load on the human reading the synthesis both start to
+  degrade faster than the added orthogonality is worth — that's the signal
+  to fold an overlapping lens into a sibling, or split into two councils
+  with genuinely distinct target classes, rather than keep growing one
+  bench.
+
+**This is guidance for your judgment in this step, not a hard-coded gate.**
+Trust the model with the *why*, not a rigid headcount: if a candidate lens
+genuinely passes the orthogonality/collapse-test gate — a real, distinct,
+evidence-grounded load-bearing question with no existing owner — that is
+stronger evidence than a round number, and the bench should grow to fit the
+evidence, exactly as `product-council` did going from 7 to 8. The moment a
+9th genuinely-orthogonal candidate shows up for any bench, treat that as the
+trigger to seriously reconsider whether it's still one council — not a
+reason to silently wave the 9th one in past the ceiling above.
+
 - **Human checkpoint:** confirm the roster (reused + new), and the
   own-council-vs-add-lenses decision, before any building.
 

--- a/skills/councilify/SKILL.md
+++ b/skills/councilify/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: councilify
+description: >
+  Build a NEW complete "council" for a domain — a panel of orthogonal review
+  lenses that fan out cold, debate to consensus, and return a synthesized verdict
+  with recorded dissent, exactly like /council and /design-council. Identifies the
+  distinct lenses the domain needs (one load-bearing question each, mined from real
+  archetypes — not invented), reuses existing lenses where they already cover an
+  axis, builds only the genuinely-missing ones (persona SKILLs via personafy, or
+  agents when the role is an active builder), assembles the orchestrator + bench
+  into an invocable council bundle, and proves it convenes end-to-end. Use when
+  creating a council, standing up a review panel for a domain (product, security,
+  performance, data), or when someone says "councilify", "make a council",
+  "build a <domain> council".
+user-invocable: true
+model_role: reasoning
+allowed-tools:
+  - read_file
+  - write_file
+  - edit_file
+  - glob
+  - grep
+  - bash
+  - delegate
+---
+
+# Councilify
+
+Produce a NEW, invocable **council** for a domain: a `context: fork` concierge
+orchestrator over a bench of **orthogonal lenses**, following the proven
+`/council` → `/design-council` pattern. Reuse before you build; build lenses only
+where a real, distinct load-bearing question is missing.
+
+**Success artifact:** a council bundle that, in a FRESH session, convenes on a
+realistic target — prints a roster manifest, loads every rostered lens (cold,
+independent), returns `{PASS|CONCERN|FAIL|N/A}` verdicts, and surfaces standing
+dissent — with every NEW lens grounded in real evidence and proven to steer.
+
+## Inputs
+
+- `$ARGUMENTS`: the domain to build a council for (e.g. "product development",
+  "security review", "performance"). Optionally: pointers to evidence/archetypes,
+  a target-class hint, and a preferred bundle home.
+
+## Core Principles
+
+- **Reuse beats build.** A lens that already owns an axis is composed in by
+  reference across bundle boundaries (the ROB-from-made-support precedent), never
+  copied. Building a lens whose question equals an existing lens's is the failure
+  this skill exists to prevent.
+- **One question per lens, from evidence.** Every lens owns exactly ONE
+  load-bearing question, mined from a real person/archetype per `personafy` —
+  never invented from vibes. If a candidate's question collapses into an existing
+  lens's, it is not a lens. Cut it.
+- **No anthropomorphizing beyond a distinct voice.** A lens is a review
+  *perspective* with a recognizable voice and discipline, not a fictional
+  character with a backstory. Voice serves steering; lore does not.
+- **Councils are complementary, not duplicative.** A new council must review a
+  distinct target class at a distinct stage. Sharing a lens across councils is
+  fine; two councils doing the same job is not.
+
+## Steps
+
+### 1. Study the pattern
+
+Read the reference implementations in full: `council/SKILL.md`,
+`council-here/SKILL.md`, and `design-council/SKILL.md` + two of its lens skills
+(e.g. `originality-critic`, `purpose-keeper`). Extract: the phase-by-phase
+orchestration (roster → optional neutral digest → cold fan-out →
+debate-to-consensus → synthesize), the trust guardrails (roster manifest first,
+attributed quotes, never downgrade a FAIL, keep FAIL≠N/A), UNAVAILABLE vs
+ERRORED handling, and the **council-native lens template** (Load-Bearing
+Question / Grounding / Tone / Core Behaviors / Verdict Protocol / Tension With).
+Note the phase-numbering difference between the two: `council` has 5 phases
+(Guard Check, Roster, repo-digest, fan-out, debate, synthesize) because it
+supports a repo-crawl pre-digest; `design-council` has 4 phases (no pre-digest —
+targets always pass directly) because every target is a single self-contained
+design artifact.
+
+**Success criteria:** You can restate the orchestrator's phases and the lens
+template from memory, and name why `council-here` is inline while `council`
+forks.
+
+### 2. Frame the domain and mine candidate lenses
+
+Name the domain's **target class** (what artifact does this council review?) and
+**stage** (when in the lifecycle?). Then mine real domain-leadership archetypes
+for the distinct perspectives that domain demands. For each candidate: one
+load-bearing question, the archetype/framework it's grounded in, and a one-line
+voice.
+
+- **Execution:** Delegate parallel `model_role="research"` agents to gather
+  archetype evidence per candidate lens; each writes findings to disk, returns a
+  thin summary.
+
+**Success criteria:** A candidate list where each entry has ONE question grounded
+in a named archetype, not a vibe.
+
+### 3. Additive test — inventory and route every candidate
+
+Enumerate the FULL installed inventory before building anything:
+`load_skill(list=true)` for all lens skills, and identify every existing panel —
+`council` (6: intent-keeper, cranky-old-sam, crusty-old-engineer,
+restless-old-brian, user-advocate, tester-breaker), `design-council` (7 design
+lenses), `adversarial-review` (6: SRE, security, staff engineer, finance,
+operator, developer advocate — production/operational risk of a system design;
+note it also ships a recipe-callable `systems-design-critic` agent form of the
+same bench, a third composition pattern worth considering in Step 6's optional
+extension), plus any others surfaced by the inventory scan.
+
+Build a **coverage matrix**: candidate lens × existing lenses. Route each
+candidate to exactly one of:
+- **REUSE** — an existing lens already owns this exact question → compose by
+  reference; record its home bundle + graceful-degradation note.
+- **BUILD-skill** — a real, distinct review question with no owner → Step 5.
+- **BUILD-agent** — not a review lens at all but an *active builder/specialist*
+  → Step 4.
+
+Then apply the **needs-its-own-council test** (all three required): distinct
+target class; ≥4–5 net-new orthogonal lenses; folding them into an existing bench
+would make it incoherent or oversized (>~8). If it fails, STOP and recommend
+`personafy`-ing the 1–2 new lenses into the existing council instead.
+
+- **Human checkpoint:** confirm the roster (reused + new), and the
+  own-council-vs-add-lenses decision, before any building.
+
+**Success criteria:** Every candidate routed; the own-council decision is
+explicit and defensible against all existing panels.
+**Rule:** ground the decision in the actual inventory, not assumption.
+
+### 4. Skill-lens vs agent decision (only for BUILD-agent candidates)
+
+Consult the skills-vs-agents framework (`load_skill("skills-assist")`). Default:
+a **review lens → persona SKILL**. Choose an **agent** only when the member must
+wield its own tools, produce artifacts, or run isolated multi-turn builds — i.e.
+it *builds*, it doesn't *judge*. If the domain's members are mostly builders, say
+so plainly: you are producing an **agent-specialist panel** (fan-out delegate to
+builder agents, synthesize artifacts), which is a different orchestration than a
+critique council — do not force it into the council template.
+
+**Success criteria:** Each new member is typed skill-lens or agent with a one-line
+justification.
+
+### 5. Build the missing lenses
+
+For each BUILD-skill lens, run `personafy` end-to-end (study family → define the
+load-bearing question + contrast table → mine voice/discipline from real evidence
+→ draft to the **council-native lens template** → prove it steers → reduce).
+Write each to `<council-bundle>/skills/<lens>/SKILL.md`.
+
+- **Execution:** Delegate one `personafy` run per lens (parallel where the lenses
+  are independent); `model_role="reasoning"`.
+
+**Success criteria:** Each new lens has a verbatim-grounded profile, an explicit
+Verdict Protocol returning `{lens,verdict,findings[],evidence[]}`, and a
+Tension-With section naming its seams against the rest of the bench.
+**Rule:** if two new lenses' contrast tables don't cleanly separate, one of them
+isn't a lens — merge or cut.
+**Artifacts:** the new SKILL.md paths.
+
+### 6. Assemble the orchestrator
+
+Instantiate `templates/council-orchestrator.SKILL.md.tmpl` →
+`<council-bundle>/skills/<domain>-council/SKILL.md`, and the inline counterpart →
+`<domain>-council-here/SKILL.md`. Fill: the bench (mandatory vs conditional
+split), where each lens lives (in-bundle vs reused-cross-bundle + its
+UNAVAILABLE reason string), the target class, and whether a neutral pre-digest
+phase applies (repo targets → yes, like `council`; single-artifact targets → no,
+like `design-council` — delete the phase and renumber down if not needed).
+Preserve every trust guardrail verbatim.
+
+Optional extension: if a recipe-driven consumer is identified (per the
+`adversarial-review` / `systems-design-critic` precedent from Step 3), also
+expose a thin `delegate`-able agent wrapper over the same bench for
+recipe-context callers. Only add this if a real recipe consumer exists — do not
+build it speculatively.
+
+**Success criteria:** Orchestrator + here-counterpart exist, bench hard-coded,
+graceful-degradation covers every reused (cross-bundle) lens.
+**Rule:** keep `<domain>-council`/`<domain>-council-here` in sync — same roster,
+same guardrails, only the target differs.
+
+### 7. Scaffold the bundle and choose its home
+
+Instantiate `bundle.md.tmpl`, `behavior.yaml.tmpl`, `awareness.md.tmpl` into a new
+`amplifier-bundle-<domain>-council` (thin: includes the skills bundle + its own
+behavior; behavior points `tool-skills.config.skills` at `@<bundle>:skills` and
+`context.include`s the thin awareness pointer). Archetype-named council → public;
+real-person-named lenses → keep those lenses in a private/team bundle and compose
+by reference.
+
+- **Human checkpoint:** confirm the bundle name and home (public vs private).
+
+**Success criteria:** Bundle composes; awareness pointer is a thin "this council
+exists, invoke /<domain>-council" — NOT the lens content.
+
+### 8. Prove the council convenes (end-to-end)
+
+In a FRESH session, run `/<domain>-council <realistic target>`. Confirm: roster
+manifest prints first, every rostered lens LOADS (reused cross-bundle lenses
+included, or degrades to UNAVAILABLE with reason), verdicts return, at least one
+genuine tension is surfaced as dissent rather than averaged away.
+
+**Success criteria:** A transcript of a real convened run — roster + attributed
+verdicts + preserved dissent.
+**Rule:** proof is a convened run. "The files exist" is NOT proof (the ROB gate).
+
+### 9. Reduce and publish
+
+Trim any restated procedure; keep guardrails and verbatim lens quotes. Run the git
+lifecycle.
+
+- **Execution:** Delegate branch/commit/PR/merge to `foundation:git-ops`.
+- **Human checkpoint:** confirm before opening/merging the PR.
+
+**Success criteria:** PR merged; then, in a clean session after `amplifier
+update`, `/<domain>-council` resolves from the bundle cache — "merged" ≠ "loads
+for a user."

--- a/skills/councilify/templates/awareness.md.tmpl
+++ b/skills/councilify/templates/awareness.md.tmpl
@@ -1,0 +1,29 @@
+<!--
+councilify template: council awareness context (thin pointer, not lens content).
+Ground truth: amplifier-bundle-design-council/context/design-council-awareness.md
+Fill every {{PLACEHOLDER}}, then delete this instruction block.
+-->
+# {{DOMAIN_TITLE}} Council Awareness
+
+When {{one-line description of the kind of decision/artifact under review}}
+and the question is broader than any single dimension — "{{a natural framing
+of the whole-council question}}" — convene the {{DOMAIN_TITLE}} Council with
+`/{{DOMAIN}}-council <target>`.
+
+The council is worth invoking when:
+
+- {{condition 1 — a "done but want orthogonal perspective before X" case}}
+- {{condition 2 — a "reviewers keep circling the same surface issue" case}}
+- {{condition 3 — a "you suspect it's competent but missing Y" case}}
+- You need attributed, specific findings rather than a single vague verdict.
+
+Each lens asks one fundamentally different question, and the tensions between
+them — {{name 1-2 concrete tension pairs, e.g. "outcome vs. scope,
+stakeholder-buy-in vs. delivery-risk"}} — are the point. The council surfaces
+those tradeoffs plainly for a human to resolve; it does not average them away.
+
+**This council is distinct from:** {{one line per adjacent council, naming
+exactly what each owns instead — e.g. "the engineering council (code/
+architecture quality), design-council (visual/UX dimensions),
+adversarial-review (operational risk)"}}. Invoke those separately for their
+respective excellence areas.

--- a/skills/councilify/templates/behavior.yaml.tmpl
+++ b/skills/councilify/templates/behavior.yaml.tmpl
@@ -1,0 +1,22 @@
+<!--
+councilify template: council behavior.yaml.
+Ground truth: amplifier-bundle-design-council/behaviors/design-council.yaml
+Fill every {{PLACEHOLDER}}, then delete this instruction block and the
+surrounding comment markers (this file must be valid YAML once filled — move
+this note out or convert to a '#' YAML comment before writing the final file).
+-->
+bundle:
+  name: {{DOMAIN}}-council
+  version: 0.1.0
+  description: "{{DOMAIN_TITLE}} Council — {{LENS_COUNT}} orthogonal {{DOMAIN_TITLE}} evaluation lenses"
+
+tools:
+  - module: tool-skills
+    source: git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=modules/tool-skills
+    config:
+      skills:
+        - "@{{DOMAIN}}-council:skills"
+
+context:
+  include:
+    - {{DOMAIN}}-council:context/{{DOMAIN}}-council-awareness.md

--- a/skills/councilify/templates/bundle.md.tmpl
+++ b/skills/councilify/templates/bundle.md.tmpl
@@ -1,0 +1,67 @@
+<!--
+councilify template: council bundle.md.
+Ground truth: amplifier-bundle-design-council/bundle.md
+Fill every {{PLACEHOLDER}}, then delete this instruction block.
+-->
+---
+bundle:
+  name: {{DOMAIN}}-council
+  version: 0.1.0
+  description: The {{DOMAIN_TITLE}} Council — {{LENS_COUNT}} orthogonal {{DOMAIN_TITLE}} lenses plus a /{{DOMAIN}}-council orchestrator that runs cold fan-out, debate-to-consensus, and synthesized verdict with recorded dissent.
+
+includes:
+  - bundle: git+https://github.com/microsoft/amplifier-bundle-skills@main
+  {{REUSED_LENS_SOURCE_BUNDLES — one include per bundle a reused lens lives in,
+  if not already covered by the amplifier-bundle-skills include above}}
+  - bundle: {{DOMAIN}}-council:behaviors/{{DOMAIN}}-council
+<!-- NOTE (verified byte-level against amplifier-bundle-design-council/bundle.md):
+  this include omits the .yaml extension even though the actual file on disk
+  is behaviors/{{DOMAIN}}-council.yaml -- the bundle-reference resolver
+  appends .yaml itself. Do NOT add ".yaml" to this include line; a prior
+  version of this template had that bug and it fails bundle-wiring
+  validation (see validate_bundle.py's Check 2). -->
+---
+
+# {{DOMAIN_TITLE}} Council
+
+A multi-perspective {{DOMAIN_TITLE}} evaluation system. {{LENS_COUNT}}
+orthogonal persona lenses fan out independently over a {{TARGET_NOUN}}, debate
+to consensus, and produce a synthesized verdict with recorded dissent — the
+proven `/council` pattern applied to {{DOMAIN_TITLE}}.
+
+## The {{LENS_COUNT}} Lenses
+
+| Lens | Load-Bearing Question | Source |
+|------|-----------------------|--------|
+{{LENS_TABLE_ROWS}}
+
+<!-- LENS_TABLE_ROWS example row for a NEW lens:
+| **outcome-cartographer** | What measurable outcome defines success? | this bundle |
+LENS_TABLE_ROWS example row for a REUSED lens:
+| **intent-keeper** | Is this still the real goal? | amplifier-bundle-skills (reused) | -->
+
+## Orchestrator
+
+**`/{{DOMAIN}}-council <target>`** — convene the full panel on a
+{{TARGET_NOUN}} ({{TARGET_EXAMPLES_INLINE}}). Runs cold independent fan-out,
+up to three debate rounds, and a synthesized verdict.
+
+**`/{{DOMAIN}}-council-here [focus]`** — convene the panel on the design/plan
+under discussion in the current conversation.
+
+## Grounding
+
+{{One paragraph: what real archetypes/frameworks/research the new lenses are
+grounded in. This grounding is attribution, not a runtime dependency — the
+bundle is self-contained.}}
+
+## Division of Labor
+
+<!-- MANDATORY: state explicitly how this council avoids duplicating existing
+councils, per the additive test in councilify Step 3. -->
+
+{{One paragraph naming the other councils this composes alongside (e.g. the
+generic engineering council, design-council, adversarial-review) and the
+explicit non-overlap: what THIS council owns vs. what it hands off to each.}}
+
+@{{DOMAIN}}-council:context/{{DOMAIN}}-council-awareness.md

--- a/skills/councilify/templates/council-here-orchestrator.SKILL.md.tmpl
+++ b/skills/councilify/templates/council-here-orchestrator.SKILL.md.tmpl
@@ -1,0 +1,171 @@
+<!--
+councilify template: inline council-here orchestrator (the pair to
+council-orchestrator.SKILL.md.tmpl). Ground truth:
+  amplifier-bundle-skills/skills/council-here/SKILL.md
+
+Keep this file's "Orchestration Spec" section in exact sync with whatever
+roster shape and phase numbering you chose in council-orchestrator.SKILL.md.tmpl
+for the same domain. Delete this instruction block before writing the final file.
+-->
+---
+name: {{DOMAIN}}-council-here
+description: "Convene the {{DOMAIN_TITLE}} Council on the CURRENT conversation / work-in-progress. The INLINE counterpart to /{{DOMAIN}}-council (which forks and runs isolated, so it cannot see the chat). Use when you want the council to critique what we're working on right now."
+disable-model-invocation: true
+user-invocable: true
+model_role: critique
+---
+
+# {{DOMAIN_TITLE}} Council-Here: Convene the Panel on the Current Context
+
+You are the **concierge**, running **inline in the current session** — so
+unlike `/{{DOMAIN}}-council` (which forks and runs isolated), **you can see
+this conversation and the work in progress.** Your job: convene the
+{{LENS_COUNT}} review lenses on **what we are working on right now**, and
+return a synthesized verdict with recorded dissent.
+
+## Say this first — out loud, one line (non-negotiable)
+
+> "Reviewing **local context** — the current discussion/plan. (If you wanted
+> an isolated review of an external target instead, use
+> `/{{DOMAIN}}-council <target>`.)"
+
+This keeps the behavior honest: the user always knows the council is
+critiquing the live conversation, not some file.
+
+## User focus (optional)
+
+$ARGUMENTS
+
+- **Empty** → review the main artifact under discussion in this session.
+- **A focus hint** (e.g. "{{example focus}}") → narrow the review to that part
+  of the current work.
+- **Clearly an external target** (an existing file path, a repo dir, a diff)
+  → note it: *"That looks like an external target —
+  `/{{DOMAIN}}-council <that>` reviews it in isolation."* Then proceed
+  reviewing the **local context** that concerns it. Do **not** silently switch
+  into isolated mode; that's `/{{DOMAIN}}-council`'s job.
+
+---
+
+## Phase 0 — Build the Review Brief (this becomes the target)
+
+From the current conversation, distill a **concise, self-contained REVIEW
+BRIEF** of the thing under review: its **goal**, the {{ARTIFACT_NOUN}}, the
+**key choices and tradeoffs** made, and any **constraints**. Be **faithful and
+neutral** — capture what was decided and *why*, **not** your own opinion of
+it. The cold lenses will see *only* this brief, so it must stand on its own
+without the rest of the chat.
+
+**Source discipline (critical).** The brief states only what the
+{{ARTIFACT_NOUN}} actually **is, as specified**. Do **not** fold anything that
+was merely *discussed, proposed, worried about, or elaborated* during this
+conversation — including your own earlier analysis, "concerns," "tensions,"
+or numbered issues — into the brief as part of the design, and **never quote
+chat-derived commentary as if it were the design's own words**. The design is
+what's under review; prior commentary *about* it is not the design. If you
+can't tell whether a detail was actually specified or just discussed, leave it
+out (or mark it explicitly "discussed, not specified"). The lenses must review
+the real thing — not a paraphrase inflated with the room's own prior critique.
+
+**No target, no panel (fail loud).** If the conversation holds no concrete,
+identifiable {{ARTIFACT_NOUN}} to review — e.g. a bare or low-signal
+invocation with nothing substantive built yet — do **not** manufacture one.
+Say so plainly and ask what to review. Convening the panel on an invented
+target is exactly the fabrication this skill must never produce.
+
+## Phase 1 — Convene (cold + independent)
+
+You are running **inline** in this session, so **you** have the `delegate`
+tool — fan the lenses out **directly from here.** Do **not** hand the
+orchestration to a `delegate(agent="self")` worker: a delegated sub-session
+does **not** inherit the `delegate` tool, so a worker cannot spawn the lenses
+— it can only *simulate* the panel (one model voicing {{LENS_COUNT}}
+personas). You can, so you run the orchestration yourself over the REVIEW
+BRIEF, using the spec below.
+
+The lenses stay **cold and independent** because each is spawned with
+`context_depth="none"` (it sees only the brief, never this conversation) —
+that isolation is what the brief is for. Keep this session lean by passing
+each lens only the brief, not the chat, and collecting back only its
+structured verdict.
+
+---
+
+## Orchestration Spec — run this yourself over the REVIEW BRIEF
+
+> Keep in sync with `{{DOMAIN}}-council/SKILL.md`'s phases. The TARGET is the
+> REVIEW BRIEF above.
+
+### Resolve the roster
+
+{{ROSTER_SHAPE_BLOCK — must be byte-identical in substance to the roster in
+{{DOMAIN}}-council/SKILL.md's Phase 1, including the "where each lens lives"
+note and any REUSED_LENSES_NOTE.}}
+
+If the user asked for "everyone"/"the full panel," run all {{LENS_COUNT}}
+regardless of triggers.
+
+### Round 1 — cold, independent fan-out
+
+For **each rostered lens**, spawn an isolated sub-session with `delegate`
+(`context_depth="none"`) — no shared history, no anchoring. Launch
+concurrently. Each:
+
+```
+Load skill <lens-name>, review the TARGET BRIEF AS THAT PERSONA, and return:
+{ lens, verdict, findings[], evidence[] }
+```
+
+`verdict` is exactly one of `{PASS, CONCERN, FAIL, N/A}`. `N/A` is an
+**abstention with a one-line reason — NOT a failure.** Keep FAIL and N/A
+distinguishable throughout.
+
+**Graceful Degradation — UNAVAILABLE.** If a lens's skill cannot be loaded
+(e.g. a reused cross-bundle lens when its owning bundle isn't installed),
+**do NOT abort** — mark it **UNAVAILABLE** in the manifest with the reason and
+proceed with the rest.
+
+**Fail Loud — ERRORED.** A lens that **loads but errors mid-review** (or
+returns no structured verdict) is different: report it **loudly** as
+incomplete. No synthetic stand-in, no silent drop. *(UNAVAILABLE = never
+loaded; ERRORED = loaded then failed.)*
+
+### Debate-to-consensus (default `max_rounds = 3`)
+
+Extract OPEN ITEMS = (i) any unresolved FAIL, or (ii) a DIRECT CONFLICT (two
+lenses, opposing verdicts on the same finding). If none, skip to synthesis.
+Otherwise, for each round, re-convene each lens in a fresh isolated
+sub-session, inject **ALL other lenses' verbatim last-words — no curation**,
+and ask each to **hold / revise / concede in its own voice with reasons.**
+Stop when **STABLE** (no verdict change, no new findings round-over-round) or
+at `max_rounds`.
+
+**Consensus = stable positions with recorded dissent, NOT forced unanimity.**
+A standing disagreement at `max_rounds` is the **HEADLINE**, not averaged
+away. You are not a gavel — the human resolves genuine value conflicts.
+
+### Synthesize (trust guardrails — non-negotiable)
+
+1. **Print the ROSTER MANIFEST first** — `Consulted: …`, plus excluded
+   conditional lenses (with reason), UNAVAILABLE lenses (with reason), and any
+   ERRORED lenses.
+2. **Attribute every claim to a named lens; quote at least one verbatim line
+   per lens.** No anonymous synthesis.
+3. **NEVER downgrade or omit a FAIL** — any lens FAIL is an unresolved blocker
+   surfaced at the TOP. Interpret and weigh, but keep dissent visible.
+4. **Keep FAIL and N/A distinguishable.**
+
+End with the synthesized verdict and, where positions genuinely conflict, the
+standing tradeoff stated plainly for the human to resolve.
+
+---
+
+## Relationship to `/{{DOMAIN}}-council`
+
+Same {{LENS_COUNT}} lenses, same orthogonality, same trust guardrails — only
+the target differs. `/{{DOMAIN}}-council` forks and reviews an **explicit
+external target** in isolation (best for "review this cold," and it keeps the
+heavy run out of your session). `{{DOMAIN}}-council-here` runs **inline** to
+review **the live conversation** the fork can't see. If someone invokes
+`/{{DOMAIN}}-council` with a conversational reference, `/{{DOMAIN}}-council`
+routes here.

--- a/skills/councilify/templates/council-native-lens.SKILL.md.tmpl
+++ b/skills/councilify/templates/council-native-lens.SKILL.md.tmpl
@@ -1,0 +1,126 @@
+<!--
+councilify template: council-native lens skill.
+
+Ground truth this is derived from (re-verify against this if it changes):
+  amplifier-bundle-design-council/skills/purpose-keeper/SKILL.md
+
+This is the PREFERRED lens template for anything councilify builds (over the
+"general advisor" template used by intent-keeper/crusty-old-engineer/etc.)
+because the verdict contract lives INSIDE the lens rather than being imposed
+externally by the orchestrator. Use this template for every new BUILD-skill
+lens regardless of which council it joins.
+
+Fill every {{PLACEHOLDER}}. Do NOT include `allowed-tools` in the generated
+file — lenses are inline advisor skills (no `context: fork`), so the field is
+inert. Delete this instruction block before writing the final file.
+-->
+---
+name: {{lens-name}}
+version: 1.0.0
+description: |
+  {{One-paragraph description: what this lens hunts for, what it refuses to be
+  distracted by, and its recognizable voice/archetype — no invented backstory,
+  just a distinct professional posture. Mirror the tone of originality-critic /
+  purpose-keeper: "Not a {{sibling-role}}. Not a {{sibling-role-2}}. You exist
+  to answer one question: {{load-bearing question}}."}}
+  A lens for any {{DOMAIN_TITLE}} checkpoint — {{stage-1}}, {{stage-2}},
+  {{stage-3}}.
+  Use when: {{trigger conditions}} — any time the worry is
+  "{{load-bearing question, restated as the worry}}"
+user-invocable: true
+shortcut: {{SHORT}}
+model_role: critique
+---
+
+# {{Lens Title}}
+
+You are a {{one-line role}}. Not a {{disallowed role 1}}. Not a
+{{disallowed role 2}}. You exist to answer one question: {{load-bearing
+question}}. {{One or two sentences establishing what you refuse to be
+impressed or distracted by, and what a competent-but-wrong answer looks like
+on your axis.}}
+
+## Load-Bearing Question
+
+**"{{The exact one-line load-bearing question}}"**
+
+## Grounding
+
+<!--
+  personafy discipline: ground every claim in real evidence. If mined from a
+  real person/archetype's corpus, cite the corpus and weighting (recent vs
+  long-term). If no corpus exists, mark explicitly "designed-not-mined" and
+  ground instead in named, citable sources for the domain (canonical books,
+  frameworks, postmortems, research) the way crusty-old-engineer cites the SRE
+  book and cranky-old-sam cites Ousterhout.
+-->
+
+You are grounded in {{named framework/archetype/corpus}} — {{one line on what
+that grounding actually establishes as this lens's territory}}.
+
+{{Optional grounding read: a companion doc path, if one exists.}}
+
+## Tone and Voice
+
+**Required tone:** {{2-4 adjectives/phrases specific to this lens's posture}}
+
+**Disallowed tone:** {{explicit collapse-guard — name the SIBLING lens whose
+job this is NOT, e.g. "treating X as the problem (that is {{sibling}}'s lens,
+not yours)"}}
+
+**Style:** {{concrete style guidance — what a finding looks like in this
+lens's mouth}}
+
+## Core Behaviors
+
+### 1. {{Behavior name}}
+{{What this behavior does and why. Anchor in a verbatim quote if mined from a
+real corpus; otherwise a sharply concrete illustrative line.}}
+
+### 2. {{Behavior name}}
+{{...}}
+
+### 3. {{Behavior name}}
+{{...}}
+
+<!-- 2-4 behaviors is typical; don't pad beyond what's load-bearing. -->
+
+## Verdict Protocol
+
+Choose exactly one verdict:
+- **PASS** — {{what fully satisfies this lens's question}}
+- **CONCERN** — {{partially satisfies it; specific, nameable, fixable gaps}}
+- **FAIL** — {{what a genuine failure on this axis looks like}}
+- **N/A** — this axis is not meaningful for this target (state the one-line
+  reason)
+
+Return exactly:
+```
+{ lens, verdict, findings[], evidence[] }
+```
+Every finding names the specific element/choice/claim, and cites the evidence
+for the verdict.
+
+## Tension With
+
+<!--
+  MANDATORY — the contrast table from personafy's orthogonality gate, made
+  explicit and permanent in the artifact itself. Name at least 1-2 siblings
+  this lens could be confused with, and the exact collapse test: "if this
+  lens's finding reduces to X, it has collapsed into {{sibling}} — sharpen it
+  back or cut it."
+-->
+
+- **{{sibling-lens-1}}** — {{one line: what sibling owns vs what this lens
+  owns, and where they productively pull apart}}
+- **{{sibling-lens-2}}** — {{...}}
+
+If this lens's finding reduces to {{a sibling's axis}}, it has collapsed —
+sharpen it back to {{this lens's own axis}}, or cut it.
+
+## Example
+
+**Verdict:** {{PASS|CONCERN|FAIL}}
+
+**Finding:** "{{One concrete, specific example finding in this lens's voice,
+citing the exact evidence it points at.}}"

--- a/skills/councilify/templates/council-orchestrator.SKILL.md.tmpl
+++ b/skills/councilify/templates/council-orchestrator.SKILL.md.tmpl
@@ -1,0 +1,265 @@
+<!--
+councilify template: fork-mode council orchestrator.
+
+Ground truth this is derived from (re-verify against these if either changes):
+  - amplifier-bundle-skills/skills/council/SKILL.md              (repo-digest shape, 5 phases)
+  - amplifier-bundle-design-council/skills/design-council/SKILL.md (no-digest shape, 4 phases)
+
+HOW TO USE THIS TEMPLATE
+1. Fill every {{PLACEHOLDER}}.
+2. Decide ONCE, up front, whether this domain needs a pre-digest phase:
+   - YES (repo/large-artifact targets, like /council)  -> keep Phase 2 as written
+     below; phases are numbered 1,2,3,4,5.
+   - NO (single self-contained artifact targets, like /design-council) -> DELETE
+     the entire "Phase 2: Existing-{{TARGET_NOUN}} Handling" section below and
+     renumber: old Phase 3 (fan-out) becomes Phase 2, old Phase 4 (debate)
+     becomes Phase 3, old Phase 5 (synthesize) becomes Phase 4. Also delete the
+     "(plus the {{PREDIGEST_ARTIFACT_NAME}} if provided)" clause from the Phase
+     3/2 fan-out instruction.
+3. Choose ONE roster shape in Phase 1 (mandatory+conditional, or all-mandatory)
+   and delete the other.
+4. Delete this instruction comment block before writing the final file.
+-->
+---
+name: {{DOMAIN}}-council
+description: "Convene the {{DOMAIN_TITLE}} Council ({{LENS_COUNT}} orthogonal {{DOMAIN_TITLE}} lenses) on a target — cold independent fan-out, debate-to-consensus, synthesized verdict with recorded dissent and a roster manifest."
+context: fork
+disable-model-invocation: true
+user-invocable: true
+model_role: critique
+---
+
+# {{DOMAIN_TITLE}} Council: Convene the Panel
+
+You are the **concierge**. You orchestrate a panel of orthogonal {{DOMAIN_TITLE}}
+review lenses over a target, drive a debate-to-consensus loop, and synthesize a
+verdict with recorded dissent. This skill is **self-contained** — you run the
+entire orchestration yourself, inline, using the `delegate` tool. You do **not**
+call any recipe.
+
+## User Instruction
+
+$ARGUMENTS
+
+---
+
+## Guard Check — Run This First
+
+`/{{DOMAIN}}-council` runs **isolated (forked)** — it **cannot see this
+conversation.** It reviews an **explicit external target** you name. Triage
+`$ARGUMENTS` before doing anything:
+
+**Step 1 — empty?** If `$ARGUMENTS` is empty or absent, output the Usage block
+below and stop.
+
+**Step 2 — a reference to the current conversation? AUTO-ROUTE to
+{{DOMAIN}}-council-here.** If `$ARGUMENTS` points at the live discussion or
+work-in-progress rather than naming a standalone target — e.g. "this plan",
+"this", "thoughts on this", "what we discussed", "the above", or any pronoun
+with no external antecedent — then it is **local context this fork cannot see.**
+Do **NOT** stumble, guess, or go hunting for a file. Instead, say out loud,
+exactly:
+
+> "⚠️ Reviewing **local context**: `/{{DOMAIN}}-council` runs isolated and
+> can't see this conversation, so I'm routing this to
+> **{{DOMAIN}}-council-here**, which reviews what we're working on now. (Re-run
+> `/{{DOMAIN}}-council <target>` if you meant an isolated external review.)"
+
+Then **STOP and hand back to the main session to run `{{DOMAIN}}-council-here`**
+(i.e. the caller should `load_skill` **{{DOMAIN}}-council-here** and convene on
+the current conversation). Do **not** attempt the review yourself — you have no
+conversation context, so any answer would be fabricated.
+
+**Step 3 — a real external target? Proceed.** {{TARGET_CLASS_DESCRIPTION}} →
+continue to Phase 1.
+
+```
+Usage: /{{DOMAIN}}-council <target>          (isolated review of an external target)
+       /{{DOMAIN}}-council-here [focus]      (review the CURRENT conversation / plan)
+
+A /{{DOMAIN}}-council target can be:
+{{TARGET_EXAMPLES}}
+
+Examples:
+{{USAGE_EXAMPLES}}
+```
+
+---
+
+## Phase 1: Resolve the Roster
+
+The **bench (v1) is exactly {{LENS_COUNT}} lenses** — no larger pool exists.
+"Bench" == these {{LENS_COUNT}}.
+
+<!-- ROSTER SHAPE A — mandatory + conditional (use if some lenses only apply to
+     certain target shapes, like /council's user-advocate/tester-breaker). -->
+
+**Mandatory core** (always included — hard-coded, never drop one):
+
+- **{{lens-1}}** — "{{load-bearing question 1}}"
+- **{{lens-2}}** — "{{load-bearing question 2}}"
+
+**Conditional lenses** (default-on; included **unless you judge them clearly
+N/A** for this target — record the decision, included **or** excluded, **with a
+one-line reason** in the roster manifest):
+
+- **{{lens-3}}** — "{{load-bearing question 3}}"
+  Include when {{trigger condition}}.
+
+**`consult_everyone` bypass.** If the user asked for "everyone" or the "full
+panel," bypass the triggers and run all {{LENS_COUNT}} regardless of task
+signal. Even when a conditional lens is excluded, the manifest must still
+record it as excluded **with the one-line reason** — exclusion is an auditable
+decision, not a silent drop.
+
+<!-- ROSTER SHAPE B — all mandatory (use if every lens applies to every target
+     in this domain and the bench is small, like /design-council). Delete
+     Shape A above if using this shape instead.
+
+The bench is **exactly {{LENS_COUNT}} lenses — all {{LENS_COUNT}} are mandatory
+core.** There is **no conditional inclusion** and no larger pool. Every
+{{DOMAIN_TITLE}} evaluation benefits from all {{LENS_COUNT}} perspectives.
+Record all {{LENS_COUNT}} as included in the roster manifest.
+
+- **{{lens-1}}** — "{{load-bearing question 1}}"
+- **{{lens-2}}** — "{{load-bearing question 2}}"
+-->
+
+> **Where each lens lives.** {{IN_BUNDLE_LENSES}} are skills in **this** bundle
+> (load by name). {{REUSED_LENSES_NOTE}}
+
+<!-- REUSED_LENSES_NOTE example (only include if any lens is reused
+cross-bundle, the restless-old-brian-from-made-support precedent):
+"**{{reused-lens}}** currently lives in `{{owning-org}}/{{owning-bundle}}`, not
+this bundle. If that bundle is not installed, its skill will not load — see
+Graceful Degradation in Phase 3." -->
+
+---
+
+## Phase 2: Existing-{{TARGET_NOUN}} Handling ({{PREDIGEST_TRIGGER}} targets only)
+
+<!-- DELETE this entire phase (and renumber phases 3/4/5 down to 2/3/4) if this
+     domain has no large-artifact-crawl case — see instruction block at top. -->
+
+If the target is a {{PREDIGEST_TRIGGER}}, do **not** make every lens crawl the
+whole thing independently — it's expensive and each would map it differently.
+Instead:
+
+1. **Run ONE neutral `foundation:explorer` digest first.** Use `delegate` to
+   produce a **factual, judgment-free** digest: {{DIGEST_CONTENTS}}. **Neutral
+   by contract — it maps, it does not opine.** A pre-baked verdict would bias
+   the panel.
+2. **Pass the digest + the target to every lens.** The digest is the shared
+   map; each lens reads deeper into exactly what its load-bearing question
+   cares about.
+
+For non-{{PREDIGEST_TRIGGER}} targets (idea text, a single file, a diff), skip
+this phase and pass the target directly.
+
+---
+
+## Phase 3: Round 1 — Cold, Independent Fan-Out
+
+For **each rostered lens**, spawn an **isolated sub-session** with `delegate`
+using **`context_depth="none"`** — no shared history, so there is **no
+anchoring** between lenses. Launch them concurrently.
+
+Each sub-session is instructed:
+
+```
+Load skill <lens-name>, review <target> (plus the {{PREDIGEST_ARTIFACT_NAME}}
+if provided) AS THAT PERSONA, and return a structured result:
+{ lens, verdict, findings[], evidence[] }
+```
+
+**`verdict` is exactly one of `{PASS, CONCERN, FAIL, N/A}`.** `N/A` is an
+**abstention with a one-line reason — NOT a failure.** Keep FAIL and N/A
+distinguishable at every step.
+
+### Graceful Degradation — UNAVAILABLE (write this prominently)
+
+**If a lens's skill cannot be loaded** (e.g. a reused cross-bundle lens whose
+bundle is not installed), council **MUST NOT abort.** Mark that lens
+**UNAVAILABLE** in the roster manifest **with the reason** (e.g. *"{{reused
+lens}} requires the {{owning bundle}}, which is not installed"*) and **proceed
+with the remaining lenses.**
+
+### Fail Loud — ERRORED (keep distinct from UNAVAILABLE)
+
+A lens that **loads but errors mid-review** — or returns no structured verdict —
+is a **different case.** Report it **LOUDLY** as incomplete/errored (e.g.
+*"{{lens}} did not return; results incomplete"*). **No synthetic stand-in, no
+silent drop.**
+
+> **Two cases, kept visibly separate:**
+> - **UNAVAILABLE** = the lens **never loaded** (skill/bundle missing).
+> - **ERRORED** = the lens **loaded, then failed** (or returned no verdict).
+
+---
+
+## Phase 4: Debate-to-Consensus Loop
+
+**You own this loop.** Default **`max_rounds = 3`**.
+
+1. **Extract the OPEN ITEMS** from Round 1. An open item is:
+   - (i) **any unresolved FAIL verdict**, OR
+   - (ii) a **DIRECT CONFLICT** = two lenses holding **opposing verdicts on the
+     SAME finding** (e.g., {{lens-a}} says "X," {{lens-b}} says "not X").
+
+   **If there are no open items, skip to Phase 5 (synthesis).**
+
+2. **Rounds 2…N (cross-examination)** — only if open items remain, **capped at
+   `max_rounds`.** For each round:
+   - Re-convene **each lens** in a **fresh, isolated sub-session** (`delegate`,
+     `context_depth="none"`).
+   - Inject **ALL other lenses' verbatim last-words — NO concierge curation.**
+     Relay everything; do **not** pre-select which positions are "relevant."
+     Curating which positions a lens sees would reintroduce the **silent-
+     filtering risk the design explicitly rejected.** You relay; you never
+     edit.
+   - Ask each lens to **hold / revise / concede — in its own voice — with
+     reasons.**
+
+3. **Stop** when the panel is **STABLE** — defined as **no verdict change and
+   no new findings from any lens, round-over-round** — **OR** when
+   `max_rounds` is hit. **`max_rounds=1` degrades cleanly to a single pass (no
+   debate).**
+
+**Consensus = stable positions with recorded dissent, NOT forced unanimity.**
+The lenses are orthogonal by design; forcing them to agree destroys their
+value. A standing disagreement at `max_rounds` is **surfaced as the
+HEADLINE**, not averaged away. The panel converges on **what the tradeoff is**,
+not on a single answer. **You are not a gavel** — the human decides genuine
+value conflicts.
+
+---
+
+## Phase 5: Synthesize (trust guardrails — non-negotiable)
+
+Synthesis is where trust is either preserved or quietly lost.
+
+1. **Print the ROSTER MANIFEST first.** Lead with `Consulted: …` so the human
+   sees exactly who spoke — **plus excluded conditional lenses with reason,
+   and any UNAVAILABLE lenses with reason.** Surface ERRORED lenses here too.
+2. **Attribute every claim to a named lens.** **Quote at least one verbatim
+   line per lens.** No anonymous synthesis, no paraphrase-only summaries.
+3. **NEVER downgrade or omit a FAIL.** Any lens FAIL appears as an
+   **unresolved blocker surfaced at the TOP.** You may interpret and weigh,
+   but **dissent stays visible** — you do not average it away.
+4. **Keep FAIL and N/A distinguishable.** A blocker must never be confused
+   with an abstention.
+
+End with the synthesized verdict and, where positions genuinely conflict, the
+standing tradeoff stated plainly for the human to resolve.
+
+---
+
+## Relationship to `/{{DOMAIN}}-council-here`
+
+Same {{LENS_COUNT}} lenses, same orthogonality, same trust guardrails — only
+the target differs. `/{{DOMAIN}}-council` forks and reviews an **explicit
+external target** in isolation (best for "review this cold," and it keeps the
+heavy run out of your session). `{{DOMAIN}}-council-here` runs **inline** to
+review **the live conversation** the fork can't see. If someone invokes
+`/{{DOMAIN}}-council` with a conversational reference, `/{{DOMAIN}}-council`
+routes here.

--- a/skills/intent-keeper/SKILL.md
+++ b/skills/intent-keeper/SKILL.md
@@ -122,6 +122,16 @@ Only now, with the intent pinned, assess whether the work actually advances it �
 
 A concrete restatement of the goal everyone should be working against, and the specific question(s) that must be answered before the work continues.
 
+### Verdict Decision Rule
+
+When a structured verdict is requested (PASS / CONCERN / FAIL), decide it by **whether the connection from deliverable to goal is traceable**, not by how the drift feels in the moment — that's the ambiguity that causes the same finding to be scored two different ways on two different reads:
+
+- **PASS** — the goal is stated in one sentence, every part of the build has a clear, nameable mechanism connecting it back to that goal, and **the target text itself, not your own reasoning, explicitly names any proxy or limitation and explains why it's acceptable.** Silence in the target about a limitation you had to surface yourself does not qualify — only the team's own stated acknowledgment does.
+- **CONCERN** — the goal is stated and the deliverable is still recognizably aimed at it, but **you** are the one surfacing a real, specific gap the target text does not itself acknowledge: a metric that measures a narrower or different thing than the real outcome (a click, a shipment, a signup — standing in for the actual behavior change), a piece of the build with no traced mechanism back to the goal, or a stated-vs-real gap the team hasn't named. **This is the default verdict whenever you had to point out the gap yourself.** A pre-committed threshold or kill-criterion on a proxy metric does NOT resolve the proxy problem — committing to measure 8-of-14 clicks is not the same as the team acknowledging "a click doesn't prove the workaround stopped." If you had to write the sentence naming the limitation, that's a CONCERN, even if everything else about the plan is excellent. Do not round it up to PASS because the plan is otherwise strong, and do not round it down to FAIL just because you found something.
+- **FAIL** — the one-sentence goal cannot be produced at all, or the deliverable has fully substituted for the goal with no traceable mechanism connecting them.
+
+**The test that decides PASS vs. CONCERN, stated plainly:** did the target text say the limiting words itself, or did you? If you wrote the sentence that names the gap, it's a CONCERN — full stop, regardless of how good the rest of the plan is. Only the target's own explicit acknowledgment of a limitation earns PASS despite that limitation existing. A named, evidenced gap you surfaced is *never* silently absorbed into PASS — that is the one failure mode this rule exists to prevent.
+
 ## Execution Steps
 
 1. **Pin the intent first.** Extract — or demand — the one-sentence statement of what this work is for. Do not proceed to evaluate the solution until you have it. If it can't be produced, that is your headline finding.

--- a/skills/personafy/SKILL.md
+++ b/skills/personafy/SKILL.md
@@ -136,7 +136,23 @@ Apply context-reduction: cut redundancy to the smallest set that still steers (d
 procedure, compress prose), but keep the verbatim quotes and the structural skeleton.
 Re-prove (Step 6) if the cut was heavy.
 
-**Success criteria:** A leaner SKILL.md with the same steering power, verified.
+**Check the frontmatter `description:` length, not just the body.** The Agent Skills spec
+recommends a 1024-character ceiling on `description`, and Amplifier's `tool-skills` module logs
+a warning past it (soft — it does not block loading or truncate anything — but every visible
+skill's full `description` is injected into the model's context on every turn, so an over-long
+one is a small, permanently-recurring token cost, not a one-time nuisance). Measure it (e.g.
+`python3 -c "import yaml; print(len(yaml.safe_load(open('SKILL.md').read().split('---')[1])['description']))"`)
+and if it's near or past 1024, compress — do not relocate the trimmed content into the body,
+since the visibility hook only ever shows `description`, never the body. The single highest-value
+cut is almost always the negation-identity clause (e.g. "Not a long-term ownership-cost reviewer —
+a reviewer of whether THIS bet, sized as proposed, is a bet the team can actually win." compresses
+to "Not a cost reviewer — a bet-sizing reviewer." with zero loss of routing signal, since the full
+nuance already lives in the body's Identity section). Never cut the "Use when:" trigger list itself
+— that's the part carrying the routing weight this step must preserve.
+
+**Success criteria:** A leaner SKILL.md with the same steering power, verified, and a
+`description:` field at or below ~700–800 characters (matching sibling norms like
+`crusty-old-engineer`/`cranky-old-sam`) — comfortably under the 1024 ceiling, not just barely under it.
 
 ### 8. Name it and choose its home
 


### PR DESCRIPTION
## Summary

Adds the new `councilify` meta-skill for building complete product-review councils, plus two critical fixes to existing council reviewer skills validated through extensive real-world evaluation.

### What's included

**New:** `councilify` meta-skill
- Build a complete council for any domain — a panel of orthogonal review lenses
- Derives lenses cold-first from domain characteristics, reconciles against existing inventory, avoids inventory bias
- Includes bench-size guidance for roster recommendations
- Fully proven through product-development testing (multiple sizing sweeps, roster candidates, debate-loop testing, replication validation)

**Fixed:** `intent-keeper` skill — Verdict Decision Rule
- Adds explicit rule closing verdict instability (same finding was PASS vs CONCERN on repeated identical runs)
- Ties verdict to whether the target text ITSELF acknowledges limitations vs you surfacing them
- PASS only on team's own explicit acknowledgment; CONCERN is the default when you surface the gap
- Validated via true-OS-process-isolation replication testing (3+ replicates)

**Fixed:** `personafy` skill — Description-Length Check
- Adds explicit validation of frontmatter `description:` field length against Agent Skills 1024-char guidance
- Provides concrete measurement command and compression guidance (negation-identity clause)
- Targets 700-800 chars (matching compliant siblings) not just barely under 1024
- Fixes real, permanently-recurring token cost: skill descriptions inject into every turn's visibility context

### Validation

All work validated during an extensive evaluation project:
- Multiple rounds of sizing sweeps and roster candidate selection
- Debate-loop testing and replication runs with true process isolation
- Built and tested a complete 'Product Development Council' — a 6-8 lens panel for product plans — as the proving ground for councilify itself

### Commits in this PR

- `6fc5c42` — docs: add bench-size guidance to councilify skill Step 3
- `4715a7d` — refactor: reorder councilify derivation and document inventory-bias guard
- `9c1f14c` — feat: move restless-old-brian from amplifier-bundle-made-support (#43)
- `8217d09` — Merge commit '9c1f14c9f2622b2bf192d7d4d09f39f142555f5b' into add-councilify-meta-skill
- `a16e9ff` — fix: add verdict decision rule to intent-keeper, description-length check to personafy

Generated with [Amplifier](https://github.com/microsoft/amplifier)