### PR TITLE
fix: don't warn about directory-name mismatch for SKILL.md at the source root

### DIFF
--- a/modules/tool-skills/amplifier_module_tool_skills/discovery.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/discovery.py
@@ -217,9 +217,18 @@ def discover_skills(skills_dir: Path) -> dict[str, SkillMetadata]:
                     f"Continuing with discovery."
                 )
 
-            # Validate directory name matches skill name (per Agent Skills Spec)
+            # Validate directory name matches skill name (per Agent Skills Spec).
+            # Skip the check when SKILL.md sits at the source root itself: a
+            # root-level SKILL.md has no author-controllable parent directory
+            # in ANY case. Git sources are cloned into hash-suffixed cache
+            # directories, and local roots (~/.amplifier/skills,
+            # $AMPLIFIER_SKILLS_DIR, user-registered source paths,
+            # #subdirectory= roots) are named by the user or harness, not the
+            # skill author — so a mismatch there is a false positive the
+            # author cannot fix.
             parent_dir_name = skill_file.parent.name
-            if name != parent_dir_name:
+            skill_dir_is_source_root = skill_file.parent.resolve() == base_resolved
+            if not skill_dir_is_source_root and name != parent_dir_name:
                 logger.warning(
                     f"Skill '{name}' at {skill_file} has mismatched directory name. "
                     f"Expected directory '{name}', but found '{parent_dir_name}'. "

--- a/modules/tool-skills/tests/test_discovery.py
+++ b/modules/tool-skills/tests/test_discovery.py
@@ -297,3 +297,61 @@ def test_non_git_dir_symlink_outside_skills_dir_is_blocked(tmp_path: Path):
         f"Evil skill escaped non-git strict boundary but should be blocked. "
         f"Found: {list(skills.keys())}"
     )
+
+
+def test_source_root_skill_skips_dirname_check(tmp_path: Path, caplog):
+    """A SKILL.md at the source root must not warn about directory name.
+
+    Git skill sources with SKILL.md at the repo root are cloned into
+    hash-suffixed cache directories (e.g. 'my-skill-865a2fe5cef82b7').
+    The author has no control over that directory name, so the
+    Agent Skills Spec dir-name check would be a false positive.
+    """
+    scan_dir = tmp_path / "my-skill-865a2fe5cef82b7"
+    scan_dir.mkdir()
+    (scan_dir / "SKILL.md").write_text(
+        "---\nname: my-skill\ndescription: A root-level skill\n---\nBody\n"
+    )
+
+    with caplog.at_level("WARNING"):
+        skills = discover_skills(scan_dir)
+
+    assert "my-skill" in skills
+    assert "mismatched directory name" not in caplog.text
+
+
+def test_nested_skill_dirname_mismatch_still_warns(tmp_path: Path, caplog):
+    """Nested skill directories keep the spec dir-name check."""
+    scan_dir = tmp_path / "skills"
+    nested = scan_dir / "wrong-dir-name"
+    nested.mkdir(parents=True)
+    (nested / "SKILL.md").write_text(
+        "---\nname: my-skill\ndescription: A nested skill\n---\nBody\n"
+    )
+
+    with caplog.at_level("WARNING"):
+        skills = discover_skills(scan_dir)
+
+    assert "my-skill" in skills
+    assert "mismatched directory name" in caplog.text
+
+
+def test_local_root_skill_skips_dirname_check(tmp_path: Path, caplog):
+    """A SKILL.md at the root of a LOCAL skills dir must not warn either.
+
+    The source-root exemption applies to any scanned root, not only git
+    cache clones: the root directory's name (~/.amplifier/skills, a
+    user-registered source path, a #subdirectory= root) is chosen by the
+    user or harness, never by the skill author.
+    """
+    scan_dir = tmp_path / "my-local-skills"
+    scan_dir.mkdir()
+    (scan_dir / "SKILL.md").write_text(
+        "---\nname: my-skill\ndescription: A local root-level skill\n---\nBody\n"
+    )
+
+    with caplog.at_level("WARNING"):
+        skills = discover_skills(scan_dir)
+
+    assert "my-skill" in skills
+    assert "mismatched directory name" not in caplog.text


### PR DESCRIPTION

## Problem

`discover_skills()` validates that a skill's directory name matches its frontmatter `name` (per
Agent Skills spec) and logs a warning on mismatch. But a root-level `SKILL.md` has no
author-controllable parent directory in ANY case:

- **Git sources** are cloned into hash-suffixed cache directories, e.g.
  `~/.amplifier/cache/skills/amplifier-skill-forge-865a2fe5fcef82b7/SKILL.md` — the name can
  never match, and the author cannot fix it.
- **Local roots** (`.amplifier/skills`, `~/.amplifier/skills`, `$AMPLIFIER_SKILLS_DIR`,
  user-registered `source` paths) and **`#subdirectory=` roots** are named by the user or
  harness, not the skill author.

Repos distributing a single skill with root-level SKILL.md are a supported source layout
(discovery is recursive and finds them), yet users see this on every session start:

```
Skill 'amplifier-skill-forge' at .../amplifier-skill-forge-865a2fe5fcef82b7/SKILL.md has
mismatched directory name. Expected directory 'amplifier-skill-forge', but found
'amplifier-skill-forge-865a2fe5fcef82b7'. ...
```

## Change

In `modules/tool-skills/amplifier_module_tool_skills/discovery.py`, skip the directory-name check
when the skill's parent directory is the source root itself:

```python
parent_dir_name = skill_file.parent.name
skill_dir_is_source_root = skill_file.parent.resolve() == base_resolved
if not skill_dir_is_source_root and name != parent_dir_name:
    logger.warning(...)  # message unchanged
```

Scope is deliberate: this exempts **any** scanned source root — git cache clones AND local /
user-registered / `#subdirectory=` roots — because the invariant is the same in every case (the
author does not choose the root directory's name). Nested skills keep the existing spec check
unchanged. `discover_skills_multi_source()` calls `discover_skills()` per source, so the fix
covers multi-source discovery too. Corollary, by design: a source registered *directly at* a
mis-named skill directory is also exempted — once a directory is handed to discovery as a root,
its name is configuration, not skill authorship.

## Alternatives considered

- **Name the git cache dir after the skill** (so the check passes): not workable — the skill name
  is unknown until after clone+parse, the hash suffix is needed for collision safety, and it would
  not cover local or `#subdirectory=` roots at all.
- **Suppress the warning only for git-cache paths**: makes discovery behavior depend on WHERE the
  root lives rather than the actual invariant (root dirs are never author-named), and adds
  path-pattern coupling between discovery and the cache layout.

## Tests

Three new tests in `modules/tool-skills/tests/test_discovery.py`:

- `test_source_root_skill_skips_dirname_check` — SKILL.md at a hash-suffixed source root: skill
  discovered, no "mismatched directory name" warning
- `test_local_root_skill_skips_dirname_check` — SKILL.md at the root of a plain local skills dir:
  discovered, no warning (pins the any-source-root semantics)
- `test_nested_skill_dirname_mismatch_still_warns` — nested skill in a wrong-named dir:
  discovered AND the warning still fires (regression guard for the spec check)

## Verification

From `modules/tool-skills/` (the module's own `.venv`/lockfile does not include pytest):

```
uv venv /tmp/testenv && uv pip install --python /tmp/testenv/bin/python \
  pytest pytest-asyncio pyyaml "amplifier-core @ git+https://github.com/microsoft/amplifier-core@main"  # verified against core 1.6.0
PYTHONPATH=. /tmp/testenv/bin/python -m pytest tests/test_discovery.py -q
```

Result: `14 passed` (11 pre-existing + 3 new). Note for anyone running the FULL module suite
(`pytest tests/`): 2 of 255 tests fail due to pre-existing environment issues — verified by
bisect, the same 2 fail identically on the base commit before this change. Also verified against real user caches: with this
change, a root-level-SKILL.md git source (amplifier-skill-forge) discovers cleanly with zero
warnings, while a genuinely mis-nested skill still warns.

(Related: michaeljabbour/amplifier-skill PR renaming its nested `amplifier-skill/` dir — that
warning is a TRUE positive this change intentionally does not silence; the two fixes are
complementary.)
