### PR TITLE
fix: add sequential execution guard to monitor skill

### DIFF
--- a/skills/monitor/SKILL.md
+++ b/skills/monitor/SKILL.md
@@ -160,7 +160,37 @@ session's accumulated history.
 **What you give up:** you cannot see the child's progress, and it cannot be
 steered once dispatched. Everything must be in the instruction: the exact
 check command, the done condition, the needs-attention conditions, the
-interval, the max duration, and the verdict-line format below.
+interval, the max duration, the verdict-line format below, and the sequential
+requirement below.
+
+**SEQUENTIAL ONLY -- state this explicitly in the instruction.** A child that
+is told to make N checks may issue all N as parallel tool calls in a single
+turn. Observed: a child asked for 15 checks emitted 15 simultaneous `tool_use`
+blocks, so all 15 "checks" sampled the same instant. It reported success. It
+had monitored nothing -- a batch of simultaneous checks can never observe a
+state change.
+
+Put this in every delegated instruction, verbatim:
+
+```
+SEQUENTIAL ONLY: Make ONE check, wait for its result, decide, then make the
+next. Never issue multiple checks in the same turn. Never batch or
+parallelize. Each check must observe the result of the previous one.
+```
+
+A condition-driven loop ("keep checking until X") is mostly self-protecting,
+because check N+1 depends on seeing check N's result. A count-driven loop
+("make N checks") has no such dependency and WILL be parallelized. Prefer
+condition-driven instructions, and state the rule regardless.
+
+**Sanity-check the result before you trust it.** A real sequential monitor
+costs roughly one LLM call per check and takes at least
+`interval x checks` of wall time. If the child returns far faster or far
+cheaper than that math predicts, it batched -- the result is void. Re-run it
+with the sequential rule stated. Measured reference: a 13-check monitor on a
+`fast` model took 14 LLM calls and 100 seconds. A batched 15-check imposter
+took 2 LLM calls and 18 seconds, and cost a third as much. Suspiciously cheap
+is the tell.
 
 **Dispatch latency is real -- measure your expectations against it.** In a live
 run, ~40 seconds elapsed between the parent issuing `delegate(...)` and the


### PR DESCRIPTION
## Summary

Add explicit documentation and detection guidance for a critical bug found during cost/performance evaluation: delegated monitoring loops can issue all N checks as parallel tool_use blocks in a single turn, defeating the entire purpose of a monitor.

## The Bug

When a delegated child is told to make N checks, it may emit all N as **parallel tool_use blocks in a single assistant turn** rather than looping sequentially.

**Observed:**
- A child asked for 15 checks emitted 15 simultaneous `tool_use` blocks in one assistant turn
- All 15 date calls returned identical timestamps
- It reported success, but had monitored nothing (simultaneous checks sample one instant only)

## The Fix

Add three components to the delegated monitor instruction section:

1. **SEQUENTIAL ONLY requirement** — verbatim text to paste into every delegated instruction that explicitly forbids parallel execution
2. **Explanation of the root cause** — why condition-driven loops are mostly self-protecting vs why count-driven loops will be parallelized
3. **Cost/duration sanity check** — how to detect when batching occurred

## Evidence & Measured Cost Impact

Real sequential 13-check monitor (genuine):
- 14 LLM calls
- 100 seconds wall time
- $0.162 total ($0.0124 per check)

Parallel 15-check imposter (batched in one turn):
- 2 LLM calls
- 18 seconds wall time
- $0.026 total ($0.00173 per check)

The fake is **cheaper and faster** — that's the tell. If a delegated monitor returns results in single-digit seconds or costs a fraction of the sequential estimate, it parallelized.

## References

Closes: Reference PR #46 (the original monitor skill addition)