### PR TITLE
feat(tool-skills): opt-in stable-prefix placement for the skills index (visibility.placement)

### DIFF
--- a/modules/tool-skills/README.md
+++ b/modules/tool-skills/README.md
@@ -166,7 +166,26 @@ tools:
       visibility:
         enabled: true                # Show skills automatically (default: true)
         max_skills_visible: 50       # Limit for large collections (default: 50)
+        placement: request           # Where the index lands (default: request)
 ```
+
+#### `visibility.placement`
+
+- `request` (default) — inject the skills index on every `provider:request`
+  (today's behavior). The index typically rides a per-request message and is
+  re-sent as fresh input tokens on every LLM call.
+- `prefix` — place the index in the **system prompt** by wrapping the context
+  module's system-prompt factory (the surface `amplifier-foundation`
+  registers via `context.set_system_prompt_factory`). Providers hoist
+  system-role content into their cached prefix (Anthropic: single system
+  content block carrying the first cache breakpoint), so the index is billed
+  once and cache-read afterwards. The wrapper re-renders from the CURRENT
+  effective skill catalog on every request (cheap catalog hash; re-render
+  only on change), so mid-session skill changes (mode overlays) refresh the
+  prefix — one cache bust per change, never a stale copy. If the context
+  module offers no factory surface, the hook logs an ERROR and falls back to
+  per-request injection (skills stay visible; placement is detectably
+  degraded).
 
 ### Configuration Priority
 

--- a/modules/tool-skills/amplifier_module_tool_skills/hooks.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/hooks.py
@@ -1,5 +1,6 @@
 """Skills visibility hook - makes available skills visible to agents."""
 
+import hashlib
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -9,6 +10,8 @@ if TYPE_CHECKING:
     from amplifier_core import ModuleCoordinator
 
 logger = logging.getLogger(__name__)
+
+VALID_PLACEMENTS = ("request", "prefix")
 
 
 class SkillsVisibilityHook:
@@ -56,9 +59,37 @@ class SkillsVisibilityHook:
         self.max_visible = config.get("max_skills_visible", 50)
         self.ephemeral = config.get("ephemeral", True)
         self.priority = config.get("priority", 20)
+        # Placement of the skills index (default "request" = per-request
+        # ephemeral injection, today's behavior byte-identical):
+        #   "request" — inject_context on every provider:request. The hook
+        #       registry merges all same-event injections into one message
+        #       (first hook's role/ephemeral win), so the index typically
+        #       rides a per-request tail message and is re-sent every call.
+        #   "prefix"  — append the index to the SYSTEM PROMPT by wrapping the
+        #       context module's system-prompt factory (the surface
+        #       amplifier-foundation _prepared.py registers via
+        #       context.set_system_prompt_factory; context-simple calls the
+        #       factory on EVERY get_messages_for_request). Providers hoist
+        #       role=system content into the stable cached prefix (anthropic:
+        #       single system block, cache_control breakpoint #1), so the
+        #       index is cached across requests and only re-billed when the
+        #       skill catalog actually changes.
+        self.placement = config.get("placement", "request")
+        if self.placement not in VALID_PLACEMENTS:
+            raise ValueError(
+                f"Invalid visibility.placement={self.placement!r}. "
+                f"Valid values: {', '.join(VALID_PLACEMENTS)}."
+            )
         self._is_forked_session = is_forked_session
         self.coordinator = coordinator
         self._tool = tool
+        # Prefix-placement state: the wrapped factory we registered (identity
+        # check for re-wrap detection), the catalog hash of the last render,
+        # and the cached rendered block (re-rendered only on catalog change).
+        self._prefix_factory: Any = None
+        self._prefix_skills_hash: str | None = None
+        self._prefix_rendered: str = ""
+        self._prefix_unavailable_logged = False
 
         logger.debug(
             f"Initialized SkillsVisibilityHook: enabled={self.enabled}, "
@@ -100,6 +131,28 @@ class SkillsVisibilityHook:
         if not self.enabled:
             return HookResult(action="continue")
 
+        if self.placement == "prefix":
+            # Prefix mode: the index lives in the system prompt (via the
+            # wrapped factory below), never as a per-request injection —
+            # returning continue here is what guarantees the two modes can
+            # never double-inject.
+            if await self._ensure_prefix_placement():
+                return HookResult(action="continue")
+            # Placement surface unavailable (no context module / no factory
+            # support). Loud, then fall back to request-mode injection so the
+            # agent is not silently blinded to its skills. The fallback is
+            # detectable: the index appears as an injected message, not in
+            # the system prompt.
+            if not self._prefix_unavailable_logged:
+                logger.error(
+                    "visibility.placement='prefix' requested but the context "
+                    "module offers no system-prompt factory surface "
+                    "(set_system_prompt_factory). Falling back to per-request "
+                    "injection — the skills index will NOT ride the stable "
+                    "cached prefix."
+                )
+                self._prefix_unavailable_logged = True
+
         effective = self._effective_skills()
         if not effective:
             return HookResult(action="continue")
@@ -116,6 +169,96 @@ class SkillsVisibilityHook:
             ephemeral=self.ephemeral,
             suppress_output=True,
         )
+
+    async def _ensure_prefix_placement(self) -> bool:
+        """Ensure the skills index rides the system prompt (stable prefix).
+
+        Wraps the context module's registered system-prompt factory so the
+        factory output becomes ``base + "\\n\\n" + skills_block``. Providers
+        hoist role=system content into their cached prefix (anthropic builds
+        a single system content block with the cache_control breakpoint), so
+        the index is billed once and cache-read afterwards — instead of
+        re-sent as fresh input tokens on every request.
+
+        Wrapping is LAZY (first provider:request) because the factory is
+        registered during session preparation (amplifier-foundation
+        _prepared.py -> context.set_system_prompt_factory) and mount order
+        vs. that registration is not guaranteed. Re-checked on every request:
+        if someone re-registered a new factory after us, we re-wrap around
+        the new one (identity check against our own wrapper).
+
+        Staleness: the factory contract is "called on EVERY
+        get_messages_for_request" (context-simple), and the wrapper renders
+        from the CURRENT effective skill catalog each call — so the prefix
+        always holds exactly one, current copy of the index. A catalog change
+        (e.g. mode overlays) changes the rendered text, which busts the
+        provider cache once; change is rare, so the cache rides otherwise.
+
+        Returns:
+            True when the index is (now) riding the system prompt; False when
+            the surface is unavailable and the caller should fall back.
+        """
+        context = self.coordinator.get("context") if self.coordinator else None
+        if context is None or not hasattr(context, "set_system_prompt_factory"):
+            return False
+
+        current = getattr(context, "_system_prompt_factory", None)
+        if current is None:
+            # No factory registered (static-system-message session). Wrapping
+            # would DROP the static system prompt (factory takes precedence
+            # over stored system messages in context-simple), so refuse.
+            return False
+        if current is self._prefix_factory:
+            return True  # already wrapped, still active
+
+        base_factory = current
+
+        async def _skills_prefixed_factory() -> str:
+            base = await base_factory()
+            block = self._render_prefix_block()
+            return f"{base}\n\n{block}" if block else base
+
+        await context.set_system_prompt_factory(_skills_prefixed_factory)
+        self._prefix_factory = _skills_prefixed_factory
+        logger.info(
+            "Skills index placement: system-prompt prefix (wrapped the "
+            "registered system-prompt factory)"
+        )
+        return True
+
+    def _render_prefix_block(self) -> str:
+        """Render the skills block for prefix placement, cached by catalog hash.
+
+        Re-renders ONLY when the effective skill catalog changes (cheap hash
+        over name/description/flags). A change means the system prompt text
+        changes, which busts the provider's prefix cache once — acceptable,
+        because catalog changes (mode overlays, runtime skill loads) are rare
+        events, and the alternative is a permanently stale index.
+        """
+        effective = self._effective_skills()
+        catalog_repr = repr(
+            sorted(
+                (
+                    name,
+                    meta.description,
+                    bool(meta.disable_model_invocation),
+                    getattr(meta, "context", None),
+                )
+                for name, meta in (effective or {}).items()
+            )
+        )
+        catalog_hash = hashlib.sha256(catalog_repr.encode()).hexdigest()
+        if catalog_hash != self._prefix_skills_hash:
+            if self._prefix_skills_hash is not None:
+                logger.info(
+                    "Skill catalog changed — refreshing skills index in the "
+                    "system prompt (one-time prefix cache bust)"
+                )
+            self._prefix_skills_hash = catalog_hash
+            self._prefix_rendered = (
+                self._format_skills_list(effective) if effective else ""
+            )
+        return self._prefix_rendered
 
     def _format_skills_list(self, skills: dict[str, Any] | None = None) -> str:
         """Format skills list as markdown with XML boundaries.

--- a/modules/tool-skills/tests/test_prefix_placement.py
+++ b/modules/tool-skills/tests/test_prefix_placement.py
@@ -1,0 +1,291 @@
+"""Tests for visibility.placement — skills index in the stable system-prompt prefix.
+
+placement="request" (default) is today's behavior byte-identical: per-request
+inject_context. placement="prefix" wraps the context module's system-prompt
+factory (the surface amplifier-foundation _prepared.py registers via
+context.set_system_prompt_factory) so the index rides the provider-cached
+system block instead of being re-sent as fresh input tokens every request.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from amplifier_module_tool_skills.discovery import SkillMetadata
+from amplifier_module_tool_skills.hooks import SkillsVisibilityHook
+
+
+@pytest.fixture
+def sample_skills():
+    """Sample skills for testing."""
+    return {
+        "python-testing": SkillMetadata(
+            name="python-testing",
+            description="Best practices for Python testing with pytest",
+            path=Path("/skills/python-testing/SKILL.md"),
+            source="/skills",
+        ),
+        "git-workflow": SkillMetadata(
+            name="git-workflow",
+            description="Git branching and commit message standards",
+            path=Path("/skills/git-workflow/SKILL.md"),
+            source="/skills",
+        ),
+    }
+
+
+@pytest.fixture
+def fork_skills():
+    """Catalog containing a fork-context skill (must be hidden in forked sessions)."""
+    return {
+        "normal-skill": SkillMetadata(
+            name="normal-skill",
+            description="A normal skill",
+            path=Path("/skills/normal-skill/SKILL.md"),
+            source="/skills",
+        ),
+        "forked-skill": SkillMetadata(
+            name="forked-skill",
+            description="A fork-context skill",
+            path=Path("/skills/forked-skill/SKILL.md"),
+            source="/skills",
+            context="fork",
+        ),
+    }
+
+
+class FakeContext:
+    """Context module exposing the system-prompt-factory surface
+    (context-simple shape: public async setter, private attribute)."""
+
+    def __init__(self, base_prompt: str = "BASE SYSTEM PROMPT"):
+        self._system_prompt_factory = self._make_base(base_prompt)
+
+    def _make_base(self, text: str):
+        async def _base() -> str:
+            return text
+
+        return _base
+
+    async def set_system_prompt_factory(self, factory) -> None:
+        self._system_prompt_factory = factory
+
+
+class FakeCoordinator:
+    """Coordinator exposing .get('context') and get_capability (hook needs both)."""
+
+    def __init__(self, context=None):
+        self._context = context
+
+    def get(self, name: str):
+        return self._context if name == "context" else None
+
+    def get_capability(self, name: str):
+        return None
+
+
+def fake_coordinator(context=None) -> Any:
+    """Typed-as-Any constructor so the duck-typed mock passes the hook's
+    ModuleCoordinator annotation (same duck-typing the hook itself relies on)."""
+    return FakeCoordinator(context)
+
+
+# ---------------------------------------------------------------------------
+# Default mode — regression: behavior byte-identical to pre-placement code
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_default_mode_unchanged(sample_skills):
+    """No placement key -> per-request inject_context, exactly as before."""
+    hook = SkillsVisibilityHook(sample_skills, {})
+    assert hook.placement == "request"
+    result = await hook.on_provider_request("provider:request", {})
+
+    assert result.action == "inject_context"
+    assert result.context_injection is not None
+    assert (
+        '<system-reminder source="hooks-skills-visibility">' in result.context_injection
+    )
+    assert "python-testing" in result.context_injection
+    assert result.context_injection_role == "system"  # pre-existing default
+    assert result.ephemeral is True
+    assert result.suppress_output is True
+
+
+@pytest.mark.asyncio
+async def test_explicit_request_placement_identical(sample_skills):
+    """placement='request' is the same as omitting the key."""
+    implicit = SkillsVisibilityHook(sample_skills, {})
+    explicit = SkillsVisibilityHook(sample_skills, {"placement": "request"})
+    r1 = await implicit.on_provider_request("provider:request", {})
+    r2 = await explicit.on_provider_request("provider:request", {})
+    assert r1.action == r2.action == "inject_context"
+    assert r1.context_injection == r2.context_injection
+
+
+def test_invalid_placement_rejected(sample_skills):
+    """Unknown placement value fails loudly at construction, not mid-session."""
+    with pytest.raises(ValueError, match="placement"):
+        SkillsVisibilityHook(sample_skills, {"placement": "sideways"})
+
+
+# ---------------------------------------------------------------------------
+# Prefix mode — placement, refresh-on-change, no-double-inject, fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prefix_mode_places_index_in_system_prompt(sample_skills):
+    """Prefix mode: factory output = base + skills block; hook injects nothing."""
+    context = FakeContext()
+    hook = SkillsVisibilityHook(
+        sample_skills,
+        {"placement": "prefix"},
+        coordinator=fake_coordinator(context),
+    )
+    result = await hook.on_provider_request("provider:request", {})
+
+    # Never a per-request injection in prefix mode (no double-inject).
+    assert result.action == "continue"
+
+    rendered = await context._system_prompt_factory()
+    assert rendered.startswith("BASE SYSTEM PROMPT")
+    assert '<system-reminder source="hooks-skills-visibility">' in rendered
+    assert "python-testing" in rendered
+    assert "git-workflow" in rendered
+
+
+@pytest.mark.asyncio
+async def test_prefix_mode_stable_across_requests(sample_skills):
+    """Unchanged catalog -> byte-identical system prompt (cacheable prefix),
+    and the cached render object is reused (no re-render)."""
+    context = FakeContext()
+    hook = SkillsVisibilityHook(
+        sample_skills,
+        {"placement": "prefix"},
+        coordinator=fake_coordinator(context),
+    )
+    await hook.on_provider_request("provider:request", {})
+    first = await context._system_prompt_factory()
+    block_obj = hook._prefix_rendered
+    await hook.on_provider_request("provider:request", {})
+    second = await context._system_prompt_factory()
+    assert first == second
+    assert hook._prefix_rendered is block_obj  # cached, not re-rendered
+
+
+@pytest.mark.asyncio
+async def test_prefix_mode_refreshes_on_catalog_change(sample_skills):
+    """Skills change mid-session (mode overlays) -> prefix holds exactly the
+    CURRENT catalog: new skill appears, removed skill disappears. No stale copies."""
+    context = FakeContext()
+    hook = SkillsVisibilityHook(
+        sample_skills,
+        {"placement": "prefix"},
+        coordinator=fake_coordinator(context),
+    )
+    await hook.on_provider_request("provider:request", {})
+    before = await context._system_prompt_factory()
+    assert "python-testing" in before
+
+    # Simulate a runtime overlay change (the dict is the hook's catalog ref).
+    sample_skills["new-mode-skill"] = SkillMetadata(
+        name="new-mode-skill",
+        description="Contributed by an active mode",
+        path=Path("/skills/new-mode-skill/SKILL.md"),
+        source="/skills",
+    )
+    del sample_skills["git-workflow"]
+
+    after = await context._system_prompt_factory()
+    assert "new-mode-skill" in after
+    assert "git-workflow" not in after
+    # Exactly one copy of the index in the prompt.
+    assert after.count('<system-reminder source="hooks-skills-visibility">') == 1
+
+
+@pytest.mark.asyncio
+async def test_prefix_mode_rewraps_after_factory_rereg(sample_skills):
+    """If someone re-registers a new base factory after our wrap, the next
+    request re-wraps around it — the index never silently disappears."""
+    context = FakeContext()
+    hook = SkillsVisibilityHook(
+        sample_skills,
+        {"placement": "prefix"},
+        coordinator=fake_coordinator(context),
+    )
+    await hook.on_provider_request("provider:request", {})
+
+    async def new_base() -> str:
+        return "REPLACED BASE"
+
+    await context.set_system_prompt_factory(new_base)  # clobbers our wrap
+    await hook.on_provider_request("provider:request", {})
+    rendered = await context._system_prompt_factory()
+    assert rendered.startswith("REPLACED BASE")
+    assert "python-testing" in rendered
+    assert rendered.count('<system-reminder source="hooks-skills-visibility">') == 1
+
+
+@pytest.mark.asyncio
+async def test_prefix_mode_fork_filtering_applies(fork_skills):
+    """Fork-context skills stay hidden from forked sub-sessions in prefix mode."""
+    context = FakeContext()
+    hook = SkillsVisibilityHook(
+        fork_skills,
+        {"placement": "prefix"},
+        is_forked_session=True,
+        coordinator=fake_coordinator(context),
+    )
+    await hook.on_provider_request("provider:request", {})
+    rendered = await context._system_prompt_factory()
+    assert "normal-skill" in rendered
+    assert "forked-skill" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_prefix_mode_falls_back_loudly_without_surface(sample_skills, caplog):
+    """No context module -> ERROR log + request-mode injection (agent never
+    silently loses skill visibility; the misplacement is detectable)."""
+    hook = SkillsVisibilityHook(
+        sample_skills,
+        {"placement": "prefix"},
+        coordinator=fake_coordinator(None),
+    )
+    with caplog.at_level("ERROR"):
+        result = await hook.on_provider_request("provider:request", {})
+    assert result.action == "inject_context"  # fallback, not silence
+    assert any("prefix" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_prefix_mode_refuses_to_replace_static_prompt(sample_skills):
+    """A session with NO registered factory (static system messages) must not
+    have its prompt replaced by a skills-only factory — falls back."""
+    context = FakeContext()
+    context._system_prompt_factory = None
+    hook = SkillsVisibilityHook(
+        sample_skills,
+        {"placement": "prefix"},
+        coordinator=fake_coordinator(context),
+    )
+    result = await hook.on_provider_request("provider:request", {})
+    assert result.action == "inject_context"  # request-mode fallback
+    assert context._system_prompt_factory is None  # untouched
+
+
+@pytest.mark.asyncio
+async def test_prefix_mode_disabled_still_respected(sample_skills):
+    """enabled=false wins over placement — nothing wrapped, nothing injected."""
+    context = FakeContext()
+    hook = SkillsVisibilityHook(
+        sample_skills,
+        {"placement": "prefix", "enabled": False},
+        coordinator=fake_coordinator(context),
+    )
+    result = await hook.on_provider_request("provider:request", {})
+    assert result.action == "continue"
+    rendered = await context._system_prompt_factory()
+    assert "hooks-skills-visibility" not in rendered


### PR DESCRIPTION
## Problem

The skills-visibility hook re-injects the full skills index (~3.5k tokens) as an ephemeral tail message on EVERY provider request. Measured in a controlled ablation (per-trial delivery verification, n=3 cells, Anthropic): the rebroadcast accounts for **32–39% of root-session cost** with zero quality gain on skill-independent tasks. Tail placement also defeats prompt caching — the block sits after the newest turn, producing a wasted cache write per turn.

## Change

New config `visibility.placement: "request" | "prefix"`, default `"request"` (existing behavior byte-identical, regression-tested). In `"prefix"` mode the index is added to the system prompt via the context module's system-prompt factory — landing in the stable cached prefix (on Anthropic, inside the system block carrying the first cache breakpoint). Staleness is handled structurally: content re-renders keyed on a catalog hash, so mode overlays that add/remove skills refresh it (one cache bust per change), and exactly one current copy ever exists. If no factory surface exists (static-prompt sessions), the hook logs a loud ERROR and falls back to request mode — the agent is never silently blinded.

## Why not `inject_context` with a system role

The hook registry merges all same-event injections into one result carrying the FIRST hook's role/ephemeral flags — a system-role injection would either drag mutable per-request content (status/todo reminders) into the cached prefix or be flattened to the merged role. The system-prompt factory is the only surface that reaches the stable prefix. (Design limitation worth knowing about upstream.)

## Measured results

Controlled A/B/C, Anthropic, root-session cost per trial, n=3 per cell, placement delivery verified per-trial in raw request payloads:
- Task 1: request-mode $1.30 / prefix $0.90 / disabled $0.79
- Task 2: request-mode $9.69 / prefix $8.24 / disabled $6.59

Quality identical to request-mode on both tasks. Prefix keeps full always-current index visibility while recovering roughly half to three-quarters of the rebroadcast premium.

## Caveat stated plainly

Skill-invocation *recall* under any placement is unmeasured (the eval tasks are skill-independent); default stays `"request"` pending that measurement.

## Tests

11 new (default-mode regression, prefix placement, refresh-on-change, fork-context filtering, never-double-inject) + 259 passing from existing suite.

Pre-existing failures: 4 (symlink boundary tests, fork model resolver, CLI --dry-run test) — not caused by this branch.

## Generated with [Amplifier](https://github.com/microsoft/amplifier)