### PR TITLE
fix: resolve @namespace:path skill sources from config.skills (deferred one-shot at first request)

### DIFF
--- a/context/skills-instructions.md
+++ b/context/skills-instructions.md
@@ -120,6 +120,8 @@ The `config.skills` list accepts three source types:
 
 Git URLs support an optional `#subdirectory=` fragment to point at a subfolder within the repo.
 
+Bundle references (`@mybundle:skills`) resolve through the session's mention resolver, which becomes available shortly after modules mount — so skills from `@`-sources register at the first request of the session rather than at mount time. If a source cannot be resolved, a warning naming it appears in the session log.
+
 > **Warning:** Do NOT use a top-level `skills:` key in your bundle frontmatter. The foundation layer does not process it -- skill sources placed there will be **silently ignored**. Always use the `tools:` config pattern shown above.
 
 ## Skills Expert

--- a/modules/tool-skills/amplifier_module_tool_skills/__init__.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/__init__.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any
 
+from amplifier_core import HookResult
 from amplifier_core import ToolResult
 
 try:
@@ -63,22 +64,31 @@ def _detect_fork_session(coordinator: "ModuleCoordinator") -> bool:
 
 async def _resolve_skill_sources(
     config: dict[str, Any], coordinator: "ModuleCoordinator"
-) -> list[Path]:
-    """Resolve skill sources from config, handling both local paths and git URLs.
+) -> tuple[list[Path], list[str]]:
+    """Resolve skill sources from config, handling local paths, git URLs, and @-mentions.
 
     Priority order:
-    1. 'skills' config (new format - supports git URLs)
+    1. 'skills' config (new format - supports git URLs and @namespace:path)
     2. 'skills_dirs' config (legacy - local paths only)
     3. 'skills_dir' config (legacy - single local path)
     4. Global settings via coordinator.config
     5. Default directories
+
+    ``@namespace:path`` sources resolve through the ``mention_resolver``
+    capability, which the app layer registers AFTER modules mount (see
+    amplifier-foundation ``bundle/_prepared.py``: ``session.initialize()``
+    runs mounts, ``mention_resolver`` is registered later). So unless a
+    resolver is already present (embedding hosts, tests), @-sources are
+    returned as *pending* for deferred one-shot resolution at the first
+    ``provider:request`` — see ``mount()`` and
+    ``SkillsTool.resolve_pending_mention_sources()``.
 
     Args:
         config: Tool configuration dict.
         coordinator: Module coordinator for accessing global config.
 
     Returns:
-        List of resolved local directory paths.
+        Tuple of (resolved local directory paths, pending @-mention sources).
     """
     sources: list[str] = []
 
@@ -120,7 +130,43 @@ async def _resolve_skill_sources(
     # 5. Fall back to defaults if no sources configured
     if not sources:
         logger.debug("No skill sources configured, using defaults")
-        return get_default_skills_dirs()
+        return get_default_skills_dirs(), []
+
+    # Partition @namespace:path sources — these resolve via the
+    # mention_resolver capability, not the filesystem/git logic below.
+    # Pre-fix, they fell into the local-path branch, failed Path.exists(),
+    # and were silently dropped: the doc-promised "@mybundle:skills" form
+    # never worked from config.
+    mention_sources = [s for s in sources if isinstance(s, str) and s.startswith("@")]
+    sources = [s for s in sources if not (isinstance(s, str) and s.startswith("@"))]
+
+    mention_dirs: list[Path] = []
+    pending_mentions: list[str] = []
+    if mention_sources:
+        resolver = (
+            coordinator.get_capability("mention_resolver") if coordinator else None
+        )
+        for source in mention_sources:
+            if resolver is None:
+                # Normal production case: resolver is registered after
+                # mounts run. Defer to first provider:request (see mount()).
+                pending_mentions.append(source)
+                continue
+            # Resolver already available (embedding hosts, tests): resolve
+            # eagerly so the skills are present from mount.
+            try:
+                resolved_mention = resolver.resolve(source)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Failed to resolve skill source %r: %s", source, exc)
+                continue
+            if resolved_mention is not None and Path(resolved_mention).exists():
+                mention_dirs.append(Path(resolved_mention))
+            else:
+                logger.warning(
+                    "Skill source %r did not resolve to an existing path; "
+                    "these skills will not be available",
+                    source,
+                )
 
     # Check if any sources are remote (need async resolution)
     has_remote = any(is_remote_source(s) for s in sources)
@@ -128,7 +174,7 @@ async def _resolve_skill_sources(
     if has_remote:
         # Resolve all sources (handles both local and remote)
         logger.info(f"Resolving {len(sources)} skill sources (includes remote)")
-        return await resolve_skill_sources(sources)
+        resolved = await resolve_skill_sources(sources)
     else:
         # All local - just expand paths
         resolved = []
@@ -138,7 +184,11 @@ async def _resolve_skill_sources(
                 resolved.append(path)
             else:
                 logger.debug(f"Local skill source does not exist: {path}")
-        return resolved if resolved else get_default_skills_dirs()
+
+    resolved.extend(mention_dirs)
+    if resolved or pending_mentions or has_remote:
+        return resolved, pending_mentions
+    return get_default_skills_dirs(), []
 
 
 async def mount(
@@ -151,8 +201,16 @@ async def mount(
         config: Tool configuration
 
     Configuration options:
-        skills: List of skill sources (local paths or git URLs)
-            Example: ["~/.amplifier/skills", "git+https://github.com/org/skills@main"]
+        skills: List of skill sources (local paths, git URLs, or @namespace:path
+            bundle references)
+            Example: ["~/.amplifier/skills",
+                      "git+https://github.com/org/skills@main",
+                      "@mybundle:skills"]
+            @namespace:path sources resolve through the mention_resolver
+            capability, which is registered after modules mount — so their
+            skills register at the FIRST provider:request (deferred one-shot
+            resolution), not at mount time, unless a resolver is already
+            present when mount runs.
         skills_dirs: Legacy alias for skills (local paths only)
         skills_dir: Legacy single directory option
 
@@ -173,10 +231,11 @@ async def mount(
     )
     coordinator.register_capability("observability.events", obs_events)
 
-    # Resolve skill sources (handles both local paths and git URLs)
-    resolved_dirs = await _resolve_skill_sources(config, coordinator)
+    # Resolve skill sources (handles local paths, git URLs, and @-mentions)
+    resolved_dirs, pending_mentions = await _resolve_skill_sources(config, coordinator)
 
     tool = SkillsTool(config, coordinator, resolved_dirs)
+    tool._pending_mention_sources = pending_mentions
 
     # Detect whether this session is a forked-skill child session. See the
     # _detect_fork_session helper docstring for why the marker lives in
@@ -194,6 +253,49 @@ async def mount(
     logger.info(
         f"Mounted SkillsTool with {len(tool.skills)} skills from {len(tool.skills_dirs)} sources"
     )
+
+    # Deferred @-mention source resolution. The mention_resolver capability is
+    # registered by the app layer AFTER session.initialize() (which is when
+    # mounts run) in both production session paths, so a mount-time
+    # get_capability("mention_resolver") returns None in every path today.
+    # Resolve @-sources one-shot at the first provider:request, by which point
+    # the resolver exists. This hook is registered UNCONDITIONALLY (not inside
+    # the visibility hook) so the fix works with visibility disabled.
+    # Priority 10 < the visibility hook's default 20, so on the same first
+    # request the merged skills are already visible in the injected index.
+    _unregister_mention_holder: list[Any] = []
+    if tool._pending_mention_sources:
+
+        async def _resolve_mention_sources_once(
+            event: str, data: dict[str, Any]
+        ) -> HookResult:
+            await tool.resolve_pending_mention_sources()
+            # One-shot: unregister after the first firing (best-effort; the
+            # handler is also a no-op on subsequent calls once pending is empty).
+            if _unregister_mention_holder and callable(_unregister_mention_holder[0]):
+                try:
+                    _unregister_mention_holder[0]()
+                except Exception:
+                    logger.debug(
+                        "Could not unregister skills-mention-sources hook",
+                        exc_info=True,
+                    )
+                _unregister_mention_holder.clear()
+            return HookResult(action="continue")
+
+        _unregister_mention_holder.append(
+            coordinator.hooks.register(
+                event="provider:request",
+                handler=_resolve_mention_sources_once,
+                priority=10,
+                name="skills-mention-sources",
+            )
+        )
+        logger.info(
+            "Deferred %d @-mention skill source(s) to first provider:request: %s",
+            len(tool._pending_mention_sources),
+            ", ".join(tool._pending_mention_sources),
+        )
 
     # Mount skills visibility hook if enabled
     visibility_config = config.get("visibility", {})
@@ -416,6 +518,11 @@ Skill Discovery:
         # Set to True by mount() when running inside a forked skill sub-session.
         # Prevents fork-from-fork infinite recursion.
         self._is_forked_session: bool = False
+        # @namespace:path sources from config that could not resolve at mount
+        # time (mention_resolver is registered after mounts run). Populated by
+        # mount(); consumed one-shot by resolve_pending_mention_sources() at
+        # the first provider:request.
+        self._pending_mention_sources: list[str] = []
 
         # Use pre-resolved dirs if provided, otherwise discover from config or defaults
         if resolved_dirs is not None:
@@ -571,6 +678,94 @@ Skill Discovery:
         # Local path
         path = Path(source).expanduser().resolve()
         return path if path.exists() else None
+
+    async def resolve_pending_mention_sources(self) -> None:
+        """Resolve deferred @namespace:path config sources and merge their skills.
+
+        Called one-shot at the first provider:request (registered by mount()).
+        The mention_resolver capability is registered by the app layer AFTER
+        modules mount, so @-sources from config.skills cannot resolve at mount
+        time; mount() stashes them in _pending_mention_sources and this method
+        resolves them on first use.
+
+        Skills merge with the same first-match-wins, in-place mutation pattern
+        as execute(source=...): existing skills win, and mutating self.skills
+        in place propagates to SkillsVisibilityHook and SkillsDiscovery, which
+        hold references to this same dict.
+
+        Failures are LOUD: any source that cannot be resolved is reported via
+        logger.warning naming the source (the pre-fix behavior silently
+        dropped @-sources at debug level).
+        """
+        pending, self._pending_mention_sources = self._pending_mention_sources, []
+        if not pending:
+            return
+
+        resolver = (
+            self.coordinator.get_capability("mention_resolver")
+            if self.coordinator
+            else None
+        )
+        if resolver is None:
+            logger.warning(
+                "Skill source(s) %s could not be resolved: no mention_resolver "
+                "capability is registered in this session. These skills will "
+                "not be available.",
+                ", ".join(repr(s) for s in pending),
+            )
+            return
+
+        for source in pending:
+            try:
+                resolved = resolver.resolve(source)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Failed to resolve skill source %r: %s", source, exc)
+                continue
+            if resolved is None:
+                logger.warning(
+                    "Skill source %r did not resolve to a path; "
+                    "these skills will not be available",
+                    source,
+                )
+                continue
+            resolved_path = Path(resolved)
+            if not resolved_path.exists():
+                logger.warning(
+                    "Skill source %r resolved to nonexistent path %s; "
+                    "these skills will not be available",
+                    source,
+                    resolved_path,
+                )
+                continue
+
+            new_skills = discover_skills(resolved_path)
+
+            # Merge with first-match-wins: existing skills take priority
+            # (same pattern as execute(source=...)).
+            added = []
+            for name, metadata in new_skills.items():
+                if name not in self.skills:
+                    self.skills[name] = metadata
+                    added.append(name)
+            self.skills_dirs.append(resolved_path)
+
+            logger.info(
+                "Resolved deferred skill source %r -> %s: %d skill(s), %d new",
+                source,
+                resolved_path,
+                len(new_skills),
+                len(added),
+            )
+
+            if self.coordinator:
+                await self.coordinator.hooks.emit(
+                    "skills:discovered",
+                    {
+                        "skill_count": len(new_skills),
+                        "skill_names": list(new_skills.keys()),
+                        "sources": [str(resolved_path)],
+                    },
+                )
 
     async def execute(self, input: dict[str, Any]) -> ToolResult:
         """

--- a/modules/tool-skills/tests/test_mention_config_sources.py
+++ b/modules/tool-skills/tests/test_mention_config_sources.py
@@ -1,0 +1,292 @@
+"""Tests for @namespace:path skill sources in config.skills (mount-time).
+
+The docs (context/skills-instructions.md) promise that config.skills accepts
+a bundle reference like "@mybundle:skills". Pre-fix, _resolve_skill_sources
+only handled git+ URLs and literal paths: an @-entry fell into the
+local-path branch, failed Path.exists(), and was silently dropped.
+
+The fix defers @-sources to a one-shot resolution at the first
+provider:request, because the mention_resolver capability is registered by
+the app layer AFTER modules mount in every production session path.
+"""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from amplifier_module_tool_skills import mount
+
+
+class MockCoordinator:
+    """Mock coordinator for testing."""
+
+    def __init__(self):
+        self.capabilities = {}
+        self.mounted_tools = {}
+        self.hooks = MockHooks()
+        self.config = {}
+
+    def register_capability(self, name: str, value):
+        self.capabilities[name] = value
+
+    def get_capability(self, name: str):
+        return self.capabilities.get(name)
+
+    def get(self, name: str):
+        return None
+
+    async def mount(self, category: str, tool, name: str):
+        self.mounted_tools[name] = tool
+
+
+class MockHooks:
+    """Mock hooks system for testing."""
+
+    def __init__(self):
+        self.listeners = {}
+        self.emitted_events = []
+        self.registered_hooks = []
+
+    def on(self, event_name: str, listener):
+        if event_name not in self.listeners:
+            self.listeners[event_name] = []
+        self.listeners[event_name].append(listener)
+
+    def register(self, event: str, handler, priority: int = 10, name: str = None):
+        self.registered_hooks.append(
+            {
+                "event": event,
+                "handler": handler,
+                "priority": priority,
+                "name": name,
+            }
+        )
+        self.on(event, handler)
+
+        def unregister():
+            if handler in self.listeners.get(event, []):
+                self.listeners[event].remove(handler)
+
+        return unregister
+
+    async def emit(self, event_name: str, data):
+        self.emitted_events.append((event_name, data))
+        # Copy: handlers may unregister themselves mid-iteration (one-shot hook)
+        for listener in list(self.listeners.get(event_name, [])):
+            await listener(event_name, data)
+
+
+class MockMentionResolver:
+    """Mock mention resolver capability."""
+
+    def __init__(self, resolve_map: dict[str, Path]):
+        self.resolve_map = resolve_map
+        self.calls = []
+
+    def resolve(self, mention: str) -> Path | None:
+        self.calls.append(mention)
+        return self.resolve_map.get(mention)
+
+
+def _make_skill(base: Path, name: str, description: str) -> Path:
+    """Create a skills dir containing one skill; return the skills dir."""
+    skill_dir = base / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"""---
+name: {name}
+description: {description}
+---
+# {name}
+"""
+    )
+    return base
+
+
+@pytest.mark.asyncio
+async def test_mention_source_resolves_at_first_provider_request(tmp_path):
+    """@-source skills merge at first provider:request; local sources unaffected."""
+    bundle_skills = _make_skill(
+        tmp_path / "bundle-skills", "bundle-skill", "Skill shipped inside a bundle"
+    )
+    local_skills = _make_skill(
+        tmp_path / "local-skills", "local-skill", "Skill from a local path"
+    )
+
+    coordinator = MockCoordinator()
+    await mount(
+        coordinator,
+        config={"skills": ["@mybundle:skills", str(local_skills)]},
+    )
+    tool = coordinator.mounted_tools["load_skill"]
+
+    # Local source resolved at mount; @-source deferred (resolver not yet registered)
+    assert "local-skill" in tool.skills
+    assert "bundle-skill" not in tool.skills
+    assert tool._pending_mention_sources == ["@mybundle:skills"]
+
+    # The dedicated one-shot hook is registered on provider:request
+    hook_names = [h["name"] for h in coordinator.hooks.registered_hooks]
+    assert "skills-mention-sources" in hook_names
+
+    # App layer registers the resolver AFTER mount (production order)
+    resolver = MockMentionResolver({"@mybundle:skills": bundle_skills})
+    coordinator.register_capability("mention_resolver", resolver)
+
+    # First provider:request triggers one-shot resolution
+    await coordinator.hooks.emit("provider:request", {})
+
+    assert "bundle-skill" in tool.skills
+    assert "local-skill" in tool.skills
+    assert bundle_skills in tool.skills_dirs
+    assert tool._pending_mention_sources == []
+    assert resolver.calls == ["@mybundle:skills"]
+
+    # One-shot: a second request does not re-resolve
+    await coordinator.hooks.emit("provider:request", {})
+    assert resolver.calls == ["@mybundle:skills"]
+
+
+@pytest.mark.asyncio
+async def test_mention_source_propagates_to_visibility_and_discovery(tmp_path):
+    """In-place merge propagates to SkillsVisibilityHook and SkillsDiscovery."""
+    bundle_skills = _make_skill(
+        tmp_path / "bundle-skills", "bundle-skill", "Skill shipped inside a bundle"
+    )
+
+    coordinator = MockCoordinator()
+    await mount(coordinator, config={"skills": ["@mybundle:skills"]})
+
+    discovery = coordinator.get_capability("skills_discovery")
+    assert discovery.find("bundle-skill") is None
+
+    coordinator.register_capability(
+        "mention_resolver", MockMentionResolver({"@mybundle:skills": bundle_skills})
+    )
+    await coordinator.hooks.emit("provider:request", {})
+
+    # SkillsDiscovery holds a reference to the same dict — sees the merge
+    assert discovery.find("bundle-skill") is not None
+    # Visibility hook renders from the same catalog
+    visibility = [
+        h
+        for h in coordinator.hooks.registered_hooks
+        if h["name"] == "skills-visibility"
+    ]
+    assert len(visibility) == 1
+    result = await visibility[0]["handler"]("provider:request", {})
+    assert "bundle-skill" in (result.context_injection or "")
+
+    # A skills:discovered event was emitted for the merged source
+    discovered = [
+        data
+        for name, data in coordinator.hooks.emitted_events
+        if name == "skills:discovered" and "bundle-skill" in data["skill_names"]
+    ]
+    assert len(discovered) == 1
+
+
+@pytest.mark.asyncio
+async def test_mention_source_warns_when_resolver_never_appears(tmp_path, caplog):
+    """If no mention_resolver ever registers, dropped sources are named LOUDLY."""
+    local_skills = _make_skill(
+        tmp_path / "local-skills", "local-skill", "Skill from a local path"
+    )
+
+    coordinator = MockCoordinator()
+    await mount(
+        coordinator,
+        config={"skills": ["@mybundle:skills", str(local_skills)]},
+    )
+    tool = coordinator.mounted_tools["load_skill"]
+
+    with caplog.at_level(logging.WARNING, logger="amplifier_module_tool_skills"):
+        await coordinator.hooks.emit("provider:request", {})
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("@mybundle:skills" in r.getMessage() for r in warnings), (
+        "Dropped @-source must be named in a WARNING"
+    )
+    assert any("mention_resolver" in r.getMessage() for r in warnings)
+
+    # Other sources unaffected
+    assert "local-skill" in tool.skills
+    assert tool._pending_mention_sources == []
+
+
+@pytest.mark.asyncio
+async def test_mention_source_warns_when_resolution_fails(tmp_path, caplog):
+    """Resolver present but returns None -> WARNING naming the source."""
+    coordinator = MockCoordinator()
+    await mount(coordinator, config={"skills": ["@mybundle:skills"]})
+    tool = coordinator.mounted_tools["load_skill"]
+
+    coordinator.register_capability("mention_resolver", MockMentionResolver({}))
+
+    with caplog.at_level(logging.WARNING, logger="amplifier_module_tool_skills"):
+        await coordinator.hooks.emit("provider:request", {})
+
+    assert any(
+        "@mybundle:skills" in r.getMessage()
+        for r in caplog.records
+        if r.levelno >= logging.WARNING
+    )
+    assert "bundle-skill" not in tool.skills
+
+
+@pytest.mark.asyncio
+async def test_mention_source_resolves_eagerly_when_resolver_present_at_mount(
+    tmp_path,
+):
+    """Future-proofing: if mention_resolver exists at mount, resolve immediately."""
+    bundle_skills = _make_skill(
+        tmp_path / "bundle-skills", "bundle-skill", "Skill shipped inside a bundle"
+    )
+
+    coordinator = MockCoordinator()
+    coordinator.register_capability(
+        "mention_resolver", MockMentionResolver({"@mybundle:skills": bundle_skills})
+    )
+    await mount(coordinator, config={"skills": ["@mybundle:skills"]})
+    tool = coordinator.mounted_tools["load_skill"]
+
+    # Skills present from mount; nothing deferred, no one-shot hook registered
+    assert "bundle-skill" in tool.skills
+    assert tool._pending_mention_sources == []
+    hook_names = [h["name"] for h in coordinator.hooks.registered_hooks]
+    assert "skills-mention-sources" not in hook_names
+
+
+@pytest.mark.asyncio
+async def test_pure_local_config_unchanged(tmp_path):
+    """Regression: configs without @-sources behave exactly as before."""
+    local_skills = _make_skill(
+        tmp_path / "local-skills", "local-skill", "Skill from a local path"
+    )
+
+    coordinator = MockCoordinator()
+    await mount(coordinator, config={"skills": [str(local_skills)]})
+    tool = coordinator.mounted_tools["load_skill"]
+
+    assert "local-skill" in tool.skills
+    assert tool._pending_mention_sources == []
+    hook_names = [h["name"] for h in coordinator.hooks.registered_hooks]
+    assert "skills-mention-sources" not in hook_names
+
+
+@pytest.mark.asyncio
+async def test_mention_only_config_does_not_fall_back_to_defaults(tmp_path):
+    """A config that lists ONLY @-sources counts as 'sources configured'.
+
+    Pre-fix, the dropped @-source made the config look empty and the tool
+    fell back to default skill directories. Post-fix, the pending source
+    suppresses the defaults fallback: the session gets exactly the skills
+    the bundle asked for (at first request), not accidental defaults.
+    """
+    coordinator = MockCoordinator()
+    await mount(coordinator, config={"skills": ["@mybundle:skills"]})
+    tool = coordinator.mounted_tools["load_skill"]
+
+    assert tool.skills_dirs == []
+    assert tool._pending_mention_sources == ["@mybundle:skills"]


### PR DESCRIPTION
## Problem

`context/skills-instructions.md` (@-mentioned into every session) promises that `config.skills` accepts a bundle reference:

| Source type | Example | When to use |
|-------------|---------|-------------|
| Bundle reference | `@mybundle:skills` | Skills shipped inside your own bundle |

But the mount-time resolver `_resolve_skill_sources` (`modules/tool-skills/amplifier_module_tool_skills/__init__.py:64-141` at `6e1843f`) only handles git+ URLs and literal paths. An `@`-entry falls into the local-path branch, fails `Path("@x:y").exists()`, and is **silently dropped** (`logger.debug` only). The runtime path already handles `@` correctly (`SkillsTool._resolve_source` via the `mention_resolver` capability) — only the documented config path was broken.

**Real-world impact:** design-council registers `@design-council:skills` (`behaviors/design-council.yaml`) — its skills never load.

**Why the naive fix doesn't work:** the `mention_resolver` capability is registered by the app layer AFTER `session.initialize()` (which is when mounts run) in both production session paths (amplifier-foundation `bundle/_prepared.py`: initialize at :581, resolver registration at :648-649 — and registration is conditional on the bundle having instruction/context; same ordering in `subprocess_runner.py`). A synchronous `get_capability("mention_resolver")` inside `mount()` returns `None` in every path today — a mount-time resolve would test green with mocks and no-op in production.

## Change

Deferred one-shot resolution, entirely module-local:

- `_resolve_skill_sources` partitions `@`-entries out of the path/git logic and returns them as *pending*. If a resolver is already present at mount (embedding hosts, tests), they resolve eagerly instead.
- `mount()` registers a dedicated one-shot `provider:request` hook (`skills-mention-sources`, priority 10 — before the visibility hook's default 20) that resolves pending sources at the first request — by which point the resolver exists — then unregisters itself. Registered unconditionally, so the fix does not depend on visibility being enabled.
- Resolved skills merge with the exact first-match-wins **in-place** mutation pattern `execute(source=...)` already uses, so `SkillsVisibilityHook` and `SkillsDiscovery` (which hold references to the same dict) see them immediately; a `skills:discovered` event is emitted per resolved source.
- **The silence is gone either way:** if the resolver never appears or resolution fails, each dropped source is named in a `logger.warning`.
- A config listing ONLY `@`-sources no longer falls back to default skill directories (sources *were* configured; pre-fix the fallback only happened because the entry was dropped).
- Docs: `mount()` docstring (was stale: "local paths or git URLs") and a note in `skills-instructions.md` that `@`-source skills register at the first request.

## Alternatives considered

- **Option B — foundation registers `mention_resolver` before `session.initialize()`:** the ecosystem-level companion fix. It would make mount-time resolution possible for every module, but it changes app-layer session preparation ordering (and the resolver's inputs — bundle graph, base paths — are assembled around that point), so it belongs in amplifier-foundation with its own analysis. The deferred one-shot here is correct on its own and keeps working (via the eager path) if Option B ever lands. Out of scope for this PR.
- **Resolving inside the visibility hook:** rejected — the fix must not depend on `visibility.enabled`.
- **Retrying on every request until a resolver appears:** rejected — unbounded retry hides misconfiguration; one shot at first request + a loud warning is deterministic and diagnosable.

## Tests

New: `tests/test_mention_config_sources.py` (7 tests — deferred resolution at first `provider:request`, one-shot semantics, propagation to visibility/discovery + `skills:discovered` event, WARNING when resolver never appears, WARNING when resolution fails, eager resolution when resolver present at mount, pure-local regression, no-defaults-fallback for mention-only configs):

```
$ uv run --extra remote-sources pytest tests/test_mention_config_sources.py -q
.......                                                                  [100%]
7 passed in 0.03s
```

Full suite on this branch:

```
$ uv run --extra remote-sources pytest -q
4 failed, 272 passed, 1 warning in 0.91s
```

The 4 failures are pre-existing and identical on `main` @ `6e1843f` (verified in a clean worktree: `4 failed, 265 passed`): `test_discovery.py::test_symlink_outside_boundary_is_skipped`, `test_discovery.py::test_non_git_dir_symlink_outside_skills_dir_is_blocked`, `test_enhanced_discovery.py::test_fork_skill_model_resolver_called_with_metadata_fields`, `test_real_session.py::test_skills_visible_in_session`. This branch adds 7 passing tests and no new failures.

```
$ uv run ruff check .
All checks passed!
$ uv run ruff format --check amplifier_module_tool_skills/__init__.py tests/test_mention_config_sources.py
2 files already formatted
```

## Live before/after proof (Digital Twin Universe)

Fresh Ubuntu 24.04 DTU; amplifier installed as a real user (`uv tool install git+https://github.com/microsoft/amplifier` → `amplifier, version 2026.08.02-e793151 (core 1.6.0)`; bundle-skills cache clone at upstream `main` = `6e1843f`). Test bundle `/root/testbundle` registers one skill via the documented form plus a git+https source as regression control:

```yaml
tools:
  - module: tool-skills
    source: git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=modules/tool-skills
    config:
      skills:
        - "@testbundle:skills"
        - "git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=skills"
```

Session prompt (identical in both runs): call `load_skill(info="dtu-proof-skill")` and `load_skill(info="image-vision")`, report verbatim.

**BEFORE (stock `main`):**

```
PROOF-SKILL: NOT-FOUND - Skill 'dtu-proof-skill' not found. Available:
adapt-skill, amplifier-tool-leverage-patterns, auth-tls-patterns, ...
GIT-SKILL: FOUND -
/root/.amplifier/cache/skills/amplifier-bundle-skills-5105b7c75992a85a/skills/image-vision/SKILL.md
```

**AFTER (this branch's module code in the exact import path — see note):**

```
PROOF-SKILL: FOUND - /root/testbundle/skills/dtu-proof-skill/SKILL.md
GIT-SKILL: FOUND -
/root/.amplifier/cache/skills/amplifier-bundle-skills-5105b7c75992a85a/skills/image-vision/SKILL.md
```

Mechanism confirmation — the AFTER session's `events.jsonl` contains the deferred-resolution discovery event (emitted at first `provider:request`, not at mount):

```json
{"event": "skills:discovered", "skill_count": 1, "skill_names": ["dtu-proof-skill"], "sources": ["/root/testbundle/skills"]}
```

git+https regression: `image-vision` (from the `#subdirectory=skills` git source) resolves identically in both runs.

**Note on how AFTER was applied:** `tool-skills` is editable-installed into the amplifier tool venv pointing at the bundle cache clone, so `~/.amplifier/settings.yaml` `sources:` and `AMPLIFIER_MODULE_TOOL_SKILLS` overrides do not change what an existing install imports (verified: env-var run left the skill unregistered and never imported the override path). AFTER was therefore applied by overlaying this branch's module file onto the exact cache path the editable install points to, verified byte-identical (`diff -q` clean), all `__pycache__` cleared, and the import path probed before the run:

```
CACHE-MODULE-IDENTICAL-TO-BRANCH
IMPORTS-FROM: /root/.amplifier/cache/amplifier-bundle-skills-5105b7c75992a85a/modules/tool-skills/amplifier_module_tool_skills/__init__.py
HAS-FIX: True
```

DTU destroyed after evidence collection.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
