### PR TITLE
fix: never let a skill git-clone prompt on the terminal

### DIFF
--- a/modules/tool-skills/amplifier_module_tool_skills/sources.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/sources.py
@@ -10,7 +10,9 @@ import asyncio
 import hashlib
 import json
 import logging
+import os
 import shutil
+import signal
 import subprocess
 from datetime import datetime
 from pathlib import Path
@@ -119,6 +121,68 @@ async def resolve_skill_source(
         return None
 
 
+def _descendants(root: int) -> list[int]:
+    """Every transitive child of `root`, read from /proc right now.
+
+    Must be read BEFORE the direct child is reaped: once it is, the orphan is
+    reparented to pid 1 and the ppid chain identifying it as ours is gone.
+    """
+    kids: dict[int, list[int]] = {}
+    try:
+        entries = os.listdir("/proc")
+    except OSError:
+        return []
+    for name in entries:
+        if not name.isdigit():
+            continue
+        try:
+            with open(f"/proc/{name}/stat", encoding="utf-8") as fh:
+                ppid = int(fh.read().rsplit(")", 1)[1].split()[1])
+        except (OSError, IndexError, ValueError):
+            continue
+        kids.setdefault(ppid, []).append(int(name))
+    out: list[int] = []
+    stack = list(kids.get(root, []))
+    while stack:
+        pid = stack.pop()
+        out.append(pid)
+        stack.extend(kids.get(pid, []))
+    return out
+
+
+def _run_clone(cmd: list[str], env: dict[str, str], timeout: int):
+    """`subprocess.run(capture_output=True, text=True, timeout=...)`, plus a
+    TREE kill on timeout.
+
+    CPython's `run()` kills only the DIRECT child when the timeout fires, so a
+    `git-remote-http` that is blocked on `/dev/tty` outlives it as an orphan
+    still holding the terminal. Defence in depth behind GIT_TERMINAL_PROMPT=0:
+    if anything in the tree ever blocks on the terminal for another reason,
+    the leak is still bounded by the timeout. The call remains SYNCHRONOUS --
+    `Popen` + `communicate(timeout=...)` is exactly what `run()` does.
+    """
+    with subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    ) as proc:
+        try:
+            out, err = proc.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            tree = _descendants(proc.pid)  # BEFORE the kill
+            proc.kill()
+            for pid in tree:
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except (ProcessLookupError, PermissionError):
+                    pass
+            proc.wait()
+            raise
+        return subprocess.CompletedProcess(proc.args, proc.returncode, out, err)
+
+
 async def _resolve_remote_source(source: str, cache_dir: Path) -> Path | None:
     """Resolve a remote source URL by cloning the git repository.
 
@@ -192,7 +256,19 @@ async def _resolve_remote_source(source: str, cache_dir: Path) -> Path | None:
                 str(tmp_path),
             ]
             logger.info(f"Cloning skill source: {url}@{ref}")
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+            # A clone issued from inside the REPL must never PROMPT. When the
+            # remote demands credentials, git opens /dev/tty BY PATH -- not the
+            # inherited stdin -- and blocks reading it. The descriptor is held
+            # by `git-remote-http`, which is NOT the process this timeout
+            # kills: CPython kills only the direct child. The orphan survives,
+            # keeps holding the terminal, and steals keystrokes from
+            # prompt_toolkit's stdin reader -- the REPL freeze.
+            # GIT_TERMINAL_PROMPT=0 makes git fail fast instead of prompting,
+            # so nothing opens /dev/tty and nothing is orphaned. Credential
+            # helpers, tokens embedded in the URL and GH_TOKEN-style auth are
+            # unaffected: only INTERACTIVE prompting is disabled.
+            env = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
+            result = _run_clone(cmd, env=env, timeout=120)
 
             if result.returncode != 0:
                 logger.error(f"Git clone failed: {result.stderr}")

--- a/modules/tool-skills/tests/test_race_condition_shared_cache.py
+++ b/modules/tool-skills/tests/test_race_condition_shared_cache.py
@@ -21,12 +21,17 @@ clone task fires per unique repo@ref.
 
 import asyncio
 import logging
+import subprocess
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from amplifier_module_tool_skills.sources import resolve_skill_sources
+
+# Intercept the clone at the module's own boundary, _run_clone, rather than at
+# subprocess.run/Popen -- see the note in test_sources.py.
+_CLONE_SEAM = "amplifier_module_tool_skills.sources._run_clone"
 
 
 # The 5 context-intelligence bundle sources that originally triggered the bug.
@@ -61,11 +66,8 @@ async def test_shared_repo_ref_cloned_exactly_once(tmp_path, caplog):
     sources = [f"{BASE_URL}#subdirectory={sd}" for sd in SUBDIRS]
     clone_call_count = 0
 
-    def fake_subprocess_run(cmd, **kwargs):
+    def fake_run_clone(cmd, **kwargs):
         nonlocal clone_call_count
-        result = MagicMock()
-        result.returncode = 0
-        result.stderr = ""
         if "clone" in cmd:
             clone_call_count += 1
             dest = Path(cmd[-1])
@@ -73,7 +75,7 @@ async def test_shared_repo_ref_cloned_exactly_once(tmp_path, caplog):
             # Populate every expected subdirectory so each source can resolve.
             for sd in SUBDIRS:
                 (dest / sd).mkdir(parents=True, exist_ok=True)
-        return result
+        return subprocess.CompletedProcess(cmd, 0, "", "")
 
     async def fake_create_subprocess_exec(*args, **kwargs):
         # Yield to the event loop — the critical interleaving point.
@@ -88,7 +90,7 @@ async def test_shared_repo_ref_cloned_exactly_once(tmp_path, caplog):
     with caplog.at_level(
         logging.WARNING, logger="amplifier_module_tool_skills.sources"
     ):
-        with patch("subprocess.run", side_effect=fake_subprocess_run):
+        with patch(_CLONE_SEAM, side_effect=fake_run_clone):
             with patch(
                 "asyncio.create_subprocess_exec",
                 side_effect=fake_create_subprocess_exec,

--- a/modules/tool-skills/tests/test_sources.py
+++ b/modules/tool-skills/tests/test_sources.py
@@ -2,12 +2,20 @@
 
 import hashlib
 import json
+import subprocess
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from amplifier_module_tool_skills.sources import _resolve_remote_source
+
+# These tests intercept the clone at the module's own boundary, _run_clone,
+# rather than at subprocess.run/Popen. _run_clone is what _resolve_remote_source
+# actually calls, so the seam stays valid even if the helper's internals change
+# (it uses Popen + communicate to allow a process-TREE kill on timeout; mocking
+# Popen here would couple these tests to CPython plumbing).
+_CLONE_SEAM = "amplifier_module_tool_skills.sources._run_clone"
 
 
 def _compute_cache_path(source: str, cache_dir: Path) -> Path:
@@ -38,19 +46,16 @@ async def test_write_cache_meta_after_successful_clone(tmp_path):
 
     def fake_clone(cmd, **kwargs):
         """Simulate git clone by creating the destination directory."""
-        result = MagicMock()
-        result.returncode = 0
-        result.stderr = ""
         if "clone" in cmd:
             dest = Path(cmd[-1])
             dest.mkdir(parents=True, exist_ok=True)
-        return result
+        return subprocess.CompletedProcess(cmd, 0, "", "")
 
     mock_sha_proc = AsyncMock()
     mock_sha_proc.returncode = 0
     mock_sha_proc.communicate = AsyncMock(return_value=(b"abc1234deadbeef\n", b""))
 
-    with patch("subprocess.run", side_effect=fake_clone):
+    with patch(_CLONE_SEAM, side_effect=fake_clone):
         with patch("asyncio.create_subprocess_exec", return_value=mock_sha_proc):
             result = await _resolve_remote_source(source, cache_dir)
 
@@ -90,20 +95,17 @@ async def test_corrupt_cache_without_metadata_triggers_reclone(tmp_path):
 
     def fake_clone(cmd, **kwargs):
         """Simulate a successful git clone (re-clone after detecting corruption)."""
-        result = MagicMock()
-        result.returncode = 0
-        result.stderr = ""
         if "clone" in cmd:
             clone_called.append(cmd)
             dest = Path(cmd[-1])
             dest.mkdir(parents=True, exist_ok=True)
-        return result
+        return subprocess.CompletedProcess(cmd, 0, "", "")
 
     mock_sha_proc = AsyncMock()
     mock_sha_proc.returncode = 0
     mock_sha_proc.communicate = AsyncMock(return_value=(b"deadbeef12345678\n", b""))
 
-    with patch("subprocess.run", side_effect=fake_clone):
+    with patch(_CLONE_SEAM, side_effect=fake_clone):
         with patch("asyncio.create_subprocess_exec", return_value=mock_sha_proc):
             result = await _resolve_remote_source(source, cache_dir)
 
@@ -132,9 +134,7 @@ async def test_failed_clone_cleans_up_partial_directory(tmp_path):
 
     def fake_failing_clone(cmd, **kwargs):
         """Simulate a git clone that fails mid-download (creates a partial directory)."""
-        result = MagicMock()
-        result.returncode = 128  # git failure exit code
-        result.stderr = (
+        stderr = (
             "error: unable to write file .git/objects/pack/pack-abc.pack: "
             "No such file or directory\nfatal: unable to rename temporary '*.pack' file"
         )
@@ -143,9 +143,9 @@ async def test_failed_clone_cleans_up_partial_directory(tmp_path):
             dest = Path(cmd[-1])
             dest.mkdir(parents=True, exist_ok=True)
             (dest / ".git").mkdir()  # partial .git directory
-        return result
+        return subprocess.CompletedProcess(cmd, 128, "", stderr)  # 128 = git failure
 
-    with patch("subprocess.run", side_effect=fake_failing_clone):
+    with patch(_CLONE_SEAM, side_effect=fake_failing_clone):
         result = await _resolve_remote_source(source, cache_dir)
 
     assert result is None, "Expected None when clone fails"
@@ -182,8 +182,8 @@ async def test_valid_cache_with_metadata_returned_without_reclone(tmp_path):
         encoding="utf-8",
     )
 
-    with patch("subprocess.run") as mock_run:
+    with patch(_CLONE_SEAM) as mock_clone:
         result = await _resolve_remote_source(source, cache_dir)
 
     assert result == valid_cache, "Expected the pre-existing valid cache path"
-    mock_run.assert_not_called()  # no git clone should happen for a valid cache
+    mock_clone.assert_not_called()  # no git clone should happen for a valid cache


### PR DESCRIPTION
## Problem

A `git clone` for a skill source, issued from inside the REPL against a remote that demands credentials, freezes the entire CLI.

git opens `/dev/tty` **by path** — not the inherited stdin — and blocks reading it. The descriptor is held by `git-remote-http`, which is *not* the process the timeout kills: CPython's `subprocess.run()` kills only the direct child. The orphan survives (measured: 140.6s past the 120s timeout, 1406/1406 ticks, 24/24 trials), keeps holding the terminal, and races prompt_toolkit's stdin reader. That reader runs on the asyncio event-loop thread via `loop.add_reader`, so when its `os.read` parks, `run_forever` cannot advance and no timer fires. The session hangs until a keypress.

## Fix

1. **`GIT_TERMINAL_PROMPT=0`** in the clone's env — git fails fast instead of opening `/dev/tty` to prompt.
2. **`_run_clone()`** replaces `subprocess.run(...)`: `Popen` + `communicate(timeout=...)` (exactly what `run()` does, still **synchronous**) plus a process-**tree** kill on `TimeoutExpired`, reading descendants from `/proc` *before* reaping the direct child (once reaped, the orphan is reparented to pid 1 and the ppid chain is gone).

## Evidence

Measured at a gate-satisfying baseline (12/12 trials firing):

| arm | park events | trials firing | p |
|---|---|---|---|
| baseline | 50 | 12/12 | — |
| `stdin=DEVNULL` (rejected) | 51 | — | closes the **wrong** channel |
| `GIT_TERMINAL_PROMPT=0` | 0 | 0/12 | 7.4e-07 |
| tree-reap on timeout | 0 | 0/12 | 7.4e-07 |
| **both (this change)** | **0** | **0/12** | **7.4e-07** |

Pooled across five candidate arms: 241 events / 72 baseline trials → 0 / 60 candidate trials, Fisher p=2.9e-33. All 241 baseline events were by-path reads on `/dev/tty` fds 6,7. Zero candidate-arm events in any channel.

End-to-end against the really-installed module, real `timeout=120`:

```
amplifier tool invoke load_skill source=git+https://<auth-required>
  before: 121.69s (frozen)   after: 1.83s
REPL-level: 37 events / 12/12 -> 0 events / 0/12 with 69% more exposure
Public-clone regression: 1.89s -> 1.80s, unchanged
```

Full evidence: [bkrabach/amplifier-tty-freeze-siteeval](https://github.com/bkrabach/amplifier-tty-freeze-siteeval) (REPORT.md, ~6,000 trials, 16 append-only rounds).

Credential helpers, tokens embedded in the URL, and `GH_TOKEN`-style auth are unaffected — only **interactive** prompting is disabled. The tree-reap is defence in depth: if anything in the tree ever blocks on the terminal for another reason, the leak stays bounded by the timeout.

## Test changes (why they're in this PR)

The fix moves the clone off `subprocess.run`, which the existing tests patched. Without a matching change those mocks silently stop intercepting and the tests hit the network against a placeholder repo. They are re-seamed onto the module's own boundary, `_run_clone` — chosen over patching `Popen` so the tests stay readable and don't couple to CPython plumbing. Mocks now return a real `subprocess.CompletedProcess` and keep their filesystem side effects.

Re-seamed: `test_sources.py` (4 tests) and `test_race_condition_shared_cache.py` (1 test).

## Verification

- **Full suite at parity with the unmodified tree**: 270 passed, 4 failed, 1 collection error — byte-identical failure set to `main` (pre-existing: 2 × `test_discovery` symlink, `test_enhanced_discovery`, `test_real_session`; collection error is a missing `amplifier_foundation` dep).
- **Seam proven load-bearing**: with the production call site bypassing `_run_clone`, all 3 clone-exercising tests fail. With `git` shimmed to fail loudly on PATH, all 5 pass and the shim is never invoked — no real git runs.
- **`python_check` at parity**: same pre-existing `FURB188` error and same warning codes as `main`; this change *removes* two warnings (`ASYNC221`, `PLW1510`) by eliminating the blocking `subprocess.run` from the async path. No new errors.
- Module still imports.

Generated with [Amplifier](https://github.com/microsoft/amplifier)
