### PR TITLE
Add goal-batch skill

### DIFF
--- a/bundle.md
+++ b/bundle.md
@@ -24,6 +24,7 @@ Provides the [Agent Skills](https://agentskills.io/specification) system for Amp
 
 | Skill | Description |
 |-------|-------------|
+| **goal-batch** | Plan a batch of independent work into isolated lanes, run each as an autonomous /goal session in its own worktree/branch/tmux, and verify and merge the results yourself |
 | **image-vision** | LLM-based image analysis across multiple providers (Anthropic, OpenAI, Gemini, Azure) |
 | **cli-packaging-patterns** | CLI tool packaging with one-line install (`uv tool install`/`npm install -g`), subcommand dispatch, 3-tier config resolution |
 | **config-state-patterns** | Configuration files with defaults merging, atomic state writes, conventional file locations (XDG), safe concurrent access |

--- a/skills/goal-batch/SKILL.md
+++ b/skills/goal-batch/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: goal-batch
+description: >
+  Plan a batch of independent work into isolated lanes, get your approval, then
+  run each lane as its own autonomous /goal session — one git worktree, one
+  branch, one tmux session each — and verify and merge the results yourself.
+  Use when work decomposes into pieces that can run at the same time: "run these
+  in parallel", "goal-batch", "launch lanes for these", "work these N tasks
+  simultaneously", "batch these as goals". Nothing launches until you have seen
+  the lane split and said go. This is NOT fire-and-forget: the orchestrating
+  session re-runs the full test suite itself after every merge and never accepts
+  a lane's own claim that it finished. NOT for bounded edits that each end in
+  their own PR — use mass-change for that. Requires git, tmux, the amplifier CLI
+  on PATH, and the goalify and monitor skills.
+user-invocable: true
+argument-hint: "<the work to batch, or where it is enumerated>"
+allowed-tools: [bash, read_file, write_file, edit_file, grep, glob, delegate, load_skill, todo]
+model_role: general
+---
+
+# Goal Batch
+
+Split large work into lanes that cannot collide, run each as an autonomous
+`/goal` session in its own worktree, and land the results through a merge pass
+you verify yourself.
+
+You are the ORCHESTRATOR. You plan, launch, watch, verify, merge, report. You do
+not do the lanes' work — if you catch yourself editing a lane's code mid-flight,
+stop and fix the goal file or relaunch instead.
+
+Every rule here was bought with a real failure across ~33 lanes of production
+use. **The rules are field-tested; this file's exact sequencing is not — it has
+driven few batches. Report what breaks.**
+
+Shape references (plan screen, approval vocabulary, DONE.json, report) live in
+`examples/plan-and-report.md`. This file is the rules.
+
+**Invoking.** `/goal-batch <batch>` in the interactive TUI, or **"Use the
+goal-batch skill and …"** in natural language — both load this skill reliably
+(measured). What does NOT work is a bare `/goal-batch …` in a headless
+`amplifier run "<prompt>"`: the model reads the token as prose and does the work
+itself, producing plausible branches with no gate, no manifest, and no lanes.
+Name the skill, or call `load_skill(skill_name="goal-batch", arguments=…)`.
+
+**Running the companion scripts.** `load_skill` returns `skill_directory`.
+Resolve every script from it — `<skill_directory>/scripts/<name>.sh` — and use
+that absolute path. Never a bare relative path: the working directory is the
+target repo, not the skill, and once this ships in a bundle the skill lives
+under a hash-suffixed cache path that changes. **Never copy a script into the
+target repo** — a real run did exactly that, leaving `.amplifier/bin/` behind as
+untracked pollution in someone else's repository.
+
+**Input** — `$ARGUMENTS`: the work to batch, or a pointer to where it is
+enumerated. If lane independence is unclear, that is Phase 1's job, not a
+question for the user yet.
+
+---
+
+## Phase 1 — Plan
+
+Read enough to decompose honestly. Lanes each own a disjoint set of files, have
+a provable outcome, and do not need a sibling to finish first.
+
+Then do the work that decides whether this batch lands:
+
+- **Collision analysis.** Map every candidate lane to the files it will touch
+  and print the intersections. Where two lanes want the same file, FOLD THEM
+  INTO ONE LANE, or assign sole ownership and have the other record its needed
+  edit as a residual. Merging two lanes that would have collided is a win.
+- **Pre-assign anything numbered** — issue IDs, task IDs, migration numbers.
+  Parallel lanes *will* both grab the next free number. Two really did take 075.
+- **Name the seams.** List files no lane owns. That is where it breaks: a
+  packaging script nobody owned shipped broken because nobody tested it. Either
+  give a lane the seam, or carry it to Phase 7 as untested.
+- **Pin the base SHA** every lane branches from, and **record current test
+  baselines** so "no regressions" is a number.
+
+No lane cap. Width is bounded by the work.
+
+## Phase 2 — Review and go
+
+**The one mandatory stop. Nothing is created and nothing launches before the
+user says go.**
+
+Show the plan on one screen — lane table, contested files, parked items, unowned
+files, per-lane time bound, watching mode. Fifteen seconds to read, one sentence
+to argue with. Shape in `examples/`.
+
+Ask questions ONLY where a wrong guess costs a relaunch: an ownership call you
+cannot make from the code, a repo you are not sure you may push to, a
+human-reserved action. Bring a plan, not a form.
+
+**Approval is conversational.** Accept a bare `go`, and accept a `go` carrying
+options — reporting cadence, per-lane time bounds, dropping a lane — and honor
+them without re-asking. Anything that is not an affirmative is feedback: revise,
+show the diff, re-present the gate. Never infer approval from enthusiasm,
+repetition, or silence.
+
+## Phase 3 — Compose the goal files
+
+Load **goalify** and use it per lane; it owns outcome-first composition and
+termination linting.
+
+**Commit the goal files to the base commit before Phase 4 cuts any worktree**,
+and pin `BASE_SHA` to that commit. Goal files written only into a worktree die
+with it; goal files committed after the worktree exists are not in it, and the
+launcher will refuse the lane.
+
+Every goal carries:
+
+- **The disjunctive exit, close to verbatim.** The load-bearing sentence — what
+  makes lanes terminate honestly instead of spinning or declaring victory:
+
+  > Complete when **either** every item reaches a terminal state, **or** it is
+  > conclusively demonstrated the remainder cannot, naming the blocker for
+  > each. Items ending FAIL or BLOCKED are residuals, not failures of the goal.
+
+- **Terminal states** `PASS` / `FAIL-named` / `BLOCKED-named` / `PENDING-HUMAN`.
+  `PENDING-HUMAN` is distinct on purpose: a lane that discharges a review by
+  assigning it to a person has deferred, not finished, and Phase 7 must show
+  that separately.
+- **Working directory + branch + base SHA.** "Work ONLY here. Do not touch the
+  main checkout or sibling worktrees."
+- **File ownership** with the residual protocol: crossing into another lane's
+  files is a defect, not a courtesy — record the needed edit and stop. Draw
+  ownership around what makes the thing *work*, not around the artifact. A lane
+  owning an icon but not the packager does not own a shippable icon.
+- **Commit early, push always.** Two tmux-server crashes cost minutes instead of
+  hours because every lane pushed as it committed.
+- **Never merge to main.** The orchestrator merges.
+- **Host capability limits, stated plainly.** A lane that authors what this box
+  cannot compile ships code that breaks on someone else's first build. Live
+  shared services are read-only evidence to a lane; tests use fixtures.
+- **The time bound**, and that exceeding it is a terminal `BUDGET` state, not a
+  reason to rush the work or skip the commit.
+- **Write `DONE.json` in the worktree root as your final act** — the terminal
+  marker. Without it, an exited session is indistinguishable from a killed one.
+  Fields: `lane, verdict, branch, head, pushed, items[], residuals[],
+  pending_human[], suite`. Shape in `examples/`.
+- **KNOWN section** — env setup, suite commands, baselines, footguns. Speed
+  aid, not criteria.
+
+## Phase 4 — Preflight
+
+Fail loud here. Never launch degraded.
+
+- **Every lane repo has a reachable remote.** `git remote -v` plus a dry push. A
+  lane with no remote is a lane whose work dies with the folder — one real run
+  produced 47MB of genuine output into a remoteless repo and landed nothing in
+  git. A waiver is the user's to give, in writing.
+- **Smoke-test the launcher once**, ~90s, thrown away, and confirm any
+  capability a lane depends on is reachable from inside a lane.
+- **Create worktrees**, skipping any that already exist rather than failing on
+  them — this path is re-entered on resume:
+  `[ -d "$WT" ] || git worktree add -b <branch> "$WT" <BASE_SHA>`
+
+**One worktree per lane is not optional.** The session workspace slug is derived
+from the working directory, so lanes sharing a directory share a workspace and
+their activity becomes unattributable.
+
+## Phase 5 — Launch and register
+
+One tmux session per lane, via the companion script:
+
+```bash
+scripts/launch_lane.sh <lane> <worktree> .amplifier/goals/<lane>.md \
+                       gb__<batch>__<lane> /tmp/gb-<batch>-<lane>.log [timeout_s]
+```
+
+It prints a manifest row and enforces four things you must not reimplement by
+hand: the tmux command contains **no user prose** (a lone apostrophe in a launch
+note silently truncated a real launch — put launch notes INSIDE the goal file);
+logging survives; the lane is wrapped in `timeout` in its own process group so a
+runaway dies with its children; and it **fails loud** if no session ID appears,
+rather than writing a blank into the crash anchor.
+
+One-phase launch is mandatory. Never start a bare `amplifier` TUI and `send-keys`
+the `/goal` into it — keystrokes sent to a busy pane get swallowed silently (one
+run left an 8MB job with a zero-byte log), and `amplifier run` *exits* when the
+goal loop ends while a TUI sits at a prompt forever, so one-phase is what makes
+session death a real signal.
+
+Both bounds are real but live at different layers: `--max-turns` is parsed by
+**`/goal`**, not by `amplifier run`, so it rides inside the prompt string
+(`/goal --max-turns 40 @file`); wall-clock is `timeout` around the process.
+`/goal` is unlimited by default on purpose (ADR-0005) — a batch should set both.
+
+**Session names `gb__<batch>__<lane>`** — double underscore because lane names
+contain hyphens. Gives `gb__*` (every lane of every batch, for the orphan sweep
+in Phase 7 and for pane-viewer match strings), `gb__<batch>__*` (one batch),
+exact (one lane). Never use `.` or `:`: tmux silently rewrites them to `_` and
+two differently-named lanes can collide.
+
+**Write the manifest** — TSV, one row per lane: `lane · worktree · branch · tmux
+· goal · log · session_id`, beside the goal files. This is the crash anchor.
+When the tmux server dies, panes are gone but git plus this file let any session
+reconstruct the batch; without it, recovery was 40 minutes of archaeology.
+
+## Phase 6 — Watch
+
+Load **monitor** for the polling discipline — it owns the SEQUENTIAL-ONLY rule
+and the batched-imposter check. Delegate the loop per its Step 3 and give it
+this batch's instrument:
+
+```bash
+scripts/batch_status.sh <manifest.tsv> <BASE_SHA>     # one line per lane, ~8ms each
+SHOW_LAST=1 scripts/batch_status.sh <manifest.tsv>    # + last 3 turns per lane
+```
+
+**Monitors lied in every prior run because they were reading `tail -1` of a
+TUI.** Give the watcher a real instrument and its job becomes mechanical. Three
+signals are counter-intuitive and the script exists to encode them:
+
+- Liveness is `events.jsonl` mtime, **not** `transcript.jsonl` mtime — the
+  transcript freezes completely while a lane delegates to a sub-agent.
+- Progress is assistant turns counted from the transcript, **not**
+  `metadata.turn_count`, which is corrupt (reports 1 for a 21-turn session).
+- Pushed is `git ls-remote`, **not** `@{upstream}`, never set by an
+  explicit-refspec push.
+
+Report per the mode approved in Phase 2. Interrupt regardless for: a lane
+`DIED`, a lane asking a human a question, or the probe itself failing twice.
+Stall thresholds (120s/900s) are starting guesses — calibrate before letting
+`STALLED` justify killing anything.
+
+**Verify the watcher's verdict yourself before acting on it.** Both false-DONE
+and false-crash have happened.
+
+**Provider rate-limit errors in a pane are healthy, not a stall.** If a lane
+dies of them, that is a model-routing problem: switch the model and relaunch.
+Do not serialize the batch.
+
+**A lane that died — crashed, or killed by its time bound — takes the same
+path:** rescue-commit anything real it banked, then relaunch the same goal with
+a RESUME note naming what the prior attempt completed with SHAs, "treat that as
+your own prior work, do not redo it", and what remains. Max 2 resumes. A lane
+that hit its bound twice is a scoping problem — report it, do not extend
+forever. Never let a bounded-out lane vanish silently from the Phase 7 report.
+
+## Phase 7 — Land
+
+**Re-verify everything. Lane self-reports are hints.** Two lanes reported green
+honestly from a suite run that predated their own last file.
+
+1. `git fetch`. Diff-stat each landed branch against main.
+2. Merge **sequentially, ascending by churn, `--no-ff`**. Run the full suite
+   yourself after EVERY merge. Verify actual test counts from result files, not
+   "BUILD SUCCESSFUL".
+3. On conflict: resolve per the lanes' own merge notes. If notes are missing or
+   intents genuinely conflict, stop and surface it rather than guessing.
+4. On red: fix at the cause, or revert that merge and report. Never weaken a
+   test to pass — the gate is doing its job.
+5. Push main. Then per lane: `git worktree remove`, delete branch local and
+   remote, `tmux kill-session`. Sweep for orphans: `tmux ls -F '#{session_name}'
+   | grep '^gb__<batch>__'` must come back empty.
+6. Report verdict-first: per-lane table (shipped, SHAs, suite results), what
+   verification caught that lanes did not self-report, residuals, anything
+   `PENDING-HUMAN`, the unowned-files list from Phase 1, and new baselines.

--- a/skills/goal-batch/examples/plan-and-report.md
+++ b/skills/goal-batch/examples/plan-and-report.md
@@ -1,0 +1,72 @@
+# goal-batch — shape references
+
+Not normative. The SKILL.md rules govern; these show what the artifacts look like
+when done well. Read only if you need the shape.
+
+## The Phase 2 plan screen
+
+```
+BATCH attend-weave    base main@86ed732    baseline: pytest 871/1, cargo 83
+
+  lane        owns                             issues    size
+  contracts   fleet-tools collection reads     008,012   M
+  tools       M365 + bash surfaces (additive)  031       S
+  continuity  the gateway rail                 049       L
+
+  contested   none — A9 folded into contracts (both rewrote fleet-tools)
+  parked      B1-B5 (methods, not code) · C3-C6 (should follow reask)
+  unowned     scripts/package.sh  ← nobody will test this
+
+  bounds      2h per lane, then TERM. no lane cap.
+  watching    every 15 min, one report when all lanes land   [default]
+              also: report as each lands · only ping me if something breaks
+
+go?
+```
+
+## Approval vocabulary actually seen in the field
+
+| They say | Means |
+|---|---|
+| `go` | launch on the shown defaults |
+| `go, tell me as each lands` | per-lane reports |
+| `go, only ping me if it breaks` | exceptions only |
+| `go, check every 30` | interval override |
+| `go, 4h on continuity` | per-lane bound override |
+| `go but drop continuity` | revise, show the one-line diff, relaunch the gate |
+
+Anything that is not an affirmative is feedback. Revise and re-present.
+
+## batch_status.sh output
+
+```
+LANE       VERDICT     IDLE   TURNS    COMMITS DIRTY PUSHED BRANCH
+contracts  WORKING     3s     127+14   2       1     0      weave/contracts
+tools      LANDED      412s   88+0     3       0     1      weave/tools
+reask      STALLED     8667s  41+0     0       11    0      weave/reask
+```
+
+Verdicts: `STARTING` · `WORKING` · `SLOW` · `STALLED` · `LANDED` ·
+`LANDED-NOT-PUSHED` · `LANDED-DIRTY` · `DIED` · `NOT-STARTED` ·
+`WORKTREE-MISSING`.
+
+`SHOW_LAST=1` appends each lane's last 3 conversation turns — that is the
+"what is it actually doing" view.
+
+## DONE.json
+
+```json
+{"lane":"contracts","verdict":"COMPLETE","branch":"weave/contracts",
+ "head":"59c853e","pushed":true,
+ "items":[{"id":"D1","state":"PASS","note":"8 red-proven gates"},
+          {"id":"D4","state":"BLOCKED","note":"074 is upstream muxplex work"}],
+ "residuals":["__bool__ undefined on Bounded — recorded, not fixed"],
+ "pending_human":[],
+ "suite":"891 passed, 1 skipped (baseline 871)"}
+```
+
+## The final report
+
+Verdict first. Per-lane: what shipped, SHAs, suite result. Then what
+verification caught that the lanes did not self-report, residuals, anything
+`PENDING-HUMAN`, the unowned-files list from Phase 1, and the new baselines.

--- a/skills/goal-batch/scripts/batch_status.sh
+++ b/skills/goal-batch/scripts/batch_status.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# batch_status.sh <manifest.tsv> [base_sha]
+#
+# One line per lane. This is the instrument the monitor reads.
+# Cost: stat-only liveness, ~8ms per lane. File size is irrelevant --
+# a 750MB events.jsonl costs the same as an empty one.
+#
+# Manifest is TSV, one row per lane, comment lines start with '#':
+#   lane <TAB> worktree <TAB> branch <TAB> tmux <TAB> goal <TAB> log <TAB> session_id
+#
+# SHOW_LAST=1  also print the last 3 top-level turns per lane.
+#
+# --- signals, and why these and not the obvious ones -------------------------
+# LIVENESS  = newest events.jsonl mtime anywhere in the lane's workspace.
+#   NOT transcript.jsonl mtime. transcript.jsonl only advances on completed
+#   ROOT-LEVEL tool calls, so a lane delegating to a sub-agent for 20 minutes
+#   has a completely frozen transcript. Measured: 4 live sessions sampled 124s
+#   apart showed ZERO transcript movement, including one blocked inside a single
+#   delegate call. events.jsonl mtime tracked wall clock (+76s/+80s over 78s).
+# PROGRESS  = assistant turns counted from the transcript.
+#   NOT metadata.turn_count -- it is corrupt. Observed: turn_count=1 on a
+#   session with 21 assistant turns; turn_count=40 on one with 348.
+# PUSHED    = git ls-remote.
+#   NOT @{upstream} -- `git push origin <branch>` sets no tracking config, so a
+#   pushed branch reads as never-pushed.
+# TERMINAL  = DONE.json written by the lane as its final act.
+#   Pane death alone cannot distinguish "goal satisfied" from "killed".
+#
+# Requires GNU find (-printf), jq, git, tmux.
+# -----------------------------------------------------------------------------
+
+set -uo pipefail
+
+MAN="${1:?usage: batch_status.sh <manifest.tsv> [base_sha]}"
+BASE_SHA="${2:-}"
+STATE="${GOAL_BATCH_STATE:-/tmp/goal-batch-state}"
+WARM="${GOAL_BATCH_WARM:-120}"    # idle < WARM -> WORKING
+COLD="${GOAL_BATCH_COLD:-900}"    # idle < COLD -> SLOW, else STALLED
+CI_BASE="${AMPLIFIER_CONTEXT_INTELLIGENCE_BASE_PATH:-$HOME/.amplifier/projects}"
+
+mkdir -p "$STATE"
+NOW=$(date +%s)
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+printf '%-14s %-19s %-8s %-10s %-8s %-6s %-7s %s\n' \
+  LANE VERDICT IDLE TURNS COMMITS DIRTY PUSHED BRANCH
+
+while IFS=$'\t' read -r lane wt branch tmuxname goal log sid; do
+  case "${lane:-}" in ''|'#'*) continue ;; esac
+
+  done_json=no
+  [ -f "$wt/DONE.json" ] && done_json=yes
+
+  # --- liveness (stat only, never a read) ------------------------------------
+  slug="$(printf '%s' "$wt" | tr '/' '-')"
+  ws="$CI_BASE/$slug/sessions"
+  newest=$(find "$ws" -maxdepth 2 -name events.jsonl -printf '%T@\n' 2>/dev/null \
+           | sort -rn | head -1)
+  newest="${newest%%.*}"
+  if [ -n "${newest:-}" ]; then idle=$(( NOW - newest )); idle_s="${idle}s"
+  else                          idle=-1;                 idle_s="n/a"; fi
+
+  # --- progress --------------------------------------------------------------
+  turns='-'
+  tr_file="$ws/${sid:-__none__}/transcript.jsonl"
+  if [ -f "$tr_file" ]; then
+    n=$(jq -r 'select(.role=="assistant")|1' "$tr_file" 2>/dev/null | wc -l | tr -d ' ')
+    prev=$(cat "$STATE/${sid}.turns" 2>/dev/null || echo 0)
+    printf '%s' "$n" > "$STATE/${sid}.turns"
+    turns="${n}+$(( n - prev ))"
+  fi
+
+  # --- git facts -------------------------------------------------------------
+  if [ -d "$wt" ]; then
+    dirty=$(git -C "$wt" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+    if [ -n "$BASE_SHA" ]; then
+      commits=$(git -C "$wt" rev-list --count "${BASE_SHA}..HEAD" 2>/dev/null || echo '-')
+    else
+      commits=$(git -C "$wt" rev-list --count HEAD 2>/dev/null || echo '-')
+    fi
+    pushed=$(timeout 20 git -C "$wt" ls-remote --heads origin "$branch" 2>/dev/null | grep -c .)
+  else
+    dirty='-'; commits='-'; pushed='-'
+  fi
+
+  alive=no
+  tmux has-session -t "$tmuxname" 2>/dev/null && alive=yes
+
+  # --- verdict (precedence matters; liveness only applies while alive) --------
+  if   [ ! -d "$wt" ];                                                    then v=WORKTREE-MISSING
+  elif [ "$done_json" = yes ] && [ "$dirty" != 0 ];                       then v=LANDED-DIRTY
+  elif [ "$done_json" = yes ] && [ "$pushed" = 0 ];                       then v=LANDED-NOT-PUSHED
+  elif [ "$done_json" = yes ];                                            then v=LANDED
+  elif [ "$alive" = yes ] && [ "$idle" -lt 0 ];                           then v=STARTING
+  elif [ "$alive" = yes ] && [ "$idle" -lt "$WARM" ];                     then v=WORKING
+  elif [ "$alive" = yes ] && [ "$idle" -lt "$COLD" ];                     then v=SLOW
+  elif [ "$alive" = yes ];                                                then v=STALLED
+  elif [ "$idle" -lt 0 ];                                                 then v=NOT-STARTED
+  else                                                                         v=DIED
+  fi
+
+  printf '%-14s %-19s %-8s %-10s %-8s %-6s %-7s %s\n' \
+    "$lane" "$v" "$idle_s" "$turns" "$commits" "$dirty" "$pushed" "$branch"
+
+  if [ "${SHOW_LAST:-0}" = 1 ] && [ -f "$tr_file" ]; then
+    "$HERE/lane_turns.sh" "$tr_file" 3 200 | sed 's/^/    /'
+  fi
+done < "$MAN"

--- a/skills/goal-batch/scripts/lane_turns.sh
+++ b/skills/goal-batch/scripts/lane_turns.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# lane_turns.sh <transcript.jsonl> [N] [CHARS]
+#
+# Print the last N TOP-LEVEL turns of an Amplifier session as one line each.
+# This is the "what is this lane actually doing" probe.
+#
+# Why this and not `tmux capture-pane`: the pane is a TUI. Its last line is
+# box-drawing characters, and the "Processing..." spinner VANISHES while a
+# sub-agent runs, so absent-spinner reads as idle when the lane is busy.
+# Measured cost of getting this wrong: 3 of 5 lanes assessed incorrectly,
+# one declared dead while it was actively landing red-proven fixes.
+#
+# Never touches events.jsonl (reaches 750MB with 100k+ token single lines).
+
+set -uo pipefail
+
+T="${1:?usage: lane_turns.sh <transcript.jsonl> [N] [CHARS]}"
+N="${2:-20}"
+CH="${3:-300}"
+
+if [ ! -f "$T" ]; then
+  echo "(no transcript yet: $T)"
+  exit 0
+fi
+
+# The select(($txt|length) > 0) filter is load-bearing: roughly 60% of assistant
+# records are tool-call-only with empty text. Without it you get blank lines and
+# no narrative.
+jq -r --argjson w "$CH" '
+  select(.role=="user" or .role=="assistant")
+  | ((.metadata | if type=="string" then (fromjson? // {}) else . end).timestamp // "?") as $ts
+  | (if (.content|type)=="string" then .content
+     else ([.content[]? | select(.type=="text").text] | join("\n")) end) as $txt
+  | select(($txt|length) > 0)
+  | "\($ts[5:19]) [\(.role[0:5])] \($txt | gsub("\\s+";" ") | .[0:$w])"
+' "$T" 2>/dev/null | tail -n "$N"

--- a/skills/goal-batch/scripts/launch_lane.sh
+++ b/skills/goal-batch/scripts/launch_lane.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# launch_lane.sh <lane> <worktree> <goal-file> <tmux-name> <log> [wall_s] [max_turns]
+#
+#   goal-file  path RELATIVE TO THE WORKTREE. It must be committed to the base
+#              commit before `git worktree add`, so every worktree contains it.
+#   wall_s     wall-clock bound, default 7200. 0 disables.
+#   max_turns  turn bound passed to /goal, default 0 (unlimited, per ADR-0005).
+#
+# Prints one manifest TSV row on success:  lane  worktree  tmux  log  session_id
+#
+# Four structural properties, each fixing a measured failure:
+#
+# 1. NO USER PROSE IN THE SHELL STRING. The tmux command carries only a
+#    fixed-shape path, validated for metacharacters. Launch notes go INSIDE the
+#    goal file. A lone apostrophe in a launch note silently truncated a real
+#    launch; this makes that unrepresentable rather than warned about.
+# 2. LOGGING SURVIVES. `tee` runs inside the wrapper, so the log that the
+#    manifest, the session-ID harvest and crash recovery all depend on exists.
+# 3. BOUNDED, AND THE WHOLE TREE DIES. `timeout` bounds wall-clock; an EXIT trap
+#    signals the entire process group, so a bounded-out lane does not leave
+#    orphaned children behind (plain `timeout` signals only its direct child).
+#    `--max-turns` bounds turns -- note it is parsed by /goal, NOT by
+#    `amplifier run`, so it goes INSIDE the prompt string.
+# 4. FAILS LOUD on no session ID rather than writing a blank into the manifest,
+#    which is the crash anchor and gets trusted during recovery.
+
+set -uo pipefail
+
+LANE="${1:?lane}"; WT="${2:?worktree}"; GOAL="${3:?goal-file (relative to worktree)}"
+TMUXNAME="${4:?tmux-name}"; LOG="${5:?log}"; WALL="${6:-7200}"; MAXTURNS="${7:-0}"
+
+[ -d "$WT" ] || { echo "FATAL $LANE: worktree missing: $WT" >&2; exit 2; }
+[ -f "$WT/$GOAL" ] || {
+  echo "FATAL $LANE: goal file not in worktree: $WT/$GOAL" >&2
+  echo "  Goal files must be COMMITTED to the base commit before 'git worktree add'." >&2
+  exit 2; }
+
+case "$GOAL" in
+  *[\'\"\ \$\`\\]*) echo "FATAL $LANE: goal path has shell metachars: $GOAL" >&2; exit 2 ;;
+esac
+case "$MAXTURNS" in ''|*[!0-9]*) echo "FATAL $LANE: max_turns must be a non-negative integer: $MAXTURNS" >&2; exit 2 ;; esac
+
+if tmux has-session -t "$TMUXNAME" 2>/dev/null; then
+  echo "SKIP $LANE: tmux session '$TMUXNAME' already live (not clobbering)"
+  exit 3
+fi
+
+# /goal parses a LEADING --max-turns; 0 means unlimited, so omit it entirely.
+if [ "$MAXTURNS" -gt 0 ]; then PROMPT="/goal --max-turns ${MAXTURNS} @${GOAL}"
+else                           PROMPT="/goal @${GOAL}"; fi
+
+# Wrapper file: keeps quoting out of the tmux command line, and owns the
+# process-group cleanup that plain `timeout` does not do.
+WRAP="$(mktemp "/tmp/gb-wrap-${LANE}-XXXXXX.sh")"
+{
+  echo '#!/usr/bin/env bash'
+  echo 'trap '\''kill -- -$$ 2>/dev/null'\'' EXIT'
+  if [ "$WALL" -gt 0 ]; then
+    printf 'timeout --signal=TERM --kill-after=60s %ss amplifier run %q 2>&1 | tee %q\n' \
+           "$WALL" "$PROMPT" "$LOG"
+  else
+    printf 'amplifier run %q 2>&1 | tee %q\n' "$PROMPT" "$LOG"
+  fi
+  printf 'echo "LANE_EXIT=${PIPESTATUS[0]} $(date -Is)" >> %q\n' "$LOG"
+} > "$WRAP"
+chmod +x "$WRAP"
+
+tmux new-session -d -s "$TMUXNAME" -c "$WT" "setsid $WRAP"
+
+# --- harvest the session ID, FAIL LOUD if it never appears -------------------
+SID=""
+for _ in $(seq 1 24); do            # up to ~60s for a cold start
+  sleep 2.5
+  SID=$(grep -am1 'Session ID:' "$LOG" 2>/dev/null | sed 's/.*Session ID: *//' | tr -d '\r')
+  [ -n "$SID" ] && break
+  tmux has-session -t "$TMUXNAME" 2>/dev/null || break   # died during startup
+done
+
+if [ -z "$SID" ]; then
+  alive=$(tmux has-session -t "$TMUXNAME" 2>/dev/null && echo yes || echo no)
+  echo "FATAL $LANE: no Session ID after 60s (session alive=$alive). Log tail:" >&2
+  tail -5 "$LOG" 2>/dev/null >&2
+  exit 4
+fi
+
+printf '%s\t%s\t%s\t%s\t%s\n' "$LANE" "$WT" "$TMUXNAME" "$LOG" "$SID"


### PR DESCRIPTION
## What this PR does

Adds the **goal-batch** skill to the curated skills collection in amplifier-bundle-skills.

The goal-batch skill enables autonomous parallel work orchestration: plan a batch of independent work into isolated lanes, get user approval, then run each lane as its own autonomous /goal session in its own git worktree, branch, and tmux session. The orchestrator watches them, verifies results, and merges with full test suite re-run after every merge.

## Evidence base

- Derived from ~33 lanes of production use across 4 repos
- Proven end-to-end in an isolated Digital Twin Universe container
- Tested with 2 real lanes, nested /goal sessions, 2 --no-ff merges
- Test suite growth: 6 → 27 tests, full teardown verified
- Companion scripts (launch_lane.sh, batch_status.sh, lane_turns.sh) have executable bit verified in git

## What's included

- **skills/goal-batch/SKILL.md**: Comprehensive skill documentation with invocation patterns, rules, and lifecycle
- **skills/goal-batch/examples/plan-and-report.md**: Example plan screen, approval vocabulary, DONE.json, and report format
- **skills/goal-batch/scripts/**: Three executable companion scripts:
  - launch_lane.sh: Set up and launch an isolated lane
  - batch_status.sh: Track lane status
  - lane_turns.sh: Coordinate lane turns and merges
- **bundle.md**: Updated curated skills table to register the skill for discovery

## Registration

Skill discovery is directory-based in this repo. The skill is now discoverable as 'goal-batch' via the standard skills mechanism. bundle.md has been updated to list it in the curated skills table with a one-liner description.