### PR TITLE
fix: goal-batch v2 — repair the launcher/status contract, harden against real-run failures

### DIFF
--- a/skills/goal-batch/SKILL.md
+++ b/skills/goal-batch/SKILL.md
@@ -12,6 +12,7 @@ description: >
   a lane's own claim that it finished. NOT for bounded edits that each end in
   their own PR — use mass-change for that. Requires git, tmux, the amplifier CLI
   on PATH, and the goalify and monitor skills.
+version: 2.0.0
 user-invocable: true
 argument-hint: "<the work to batch, or where it is enumerated>"
 allowed-tools: [bash, read_file, write_file, edit_file, grep, glob, delegate, load_skill, todo]
@@ -28,9 +29,8 @@ You are the ORCHESTRATOR. You plan, launch, watch, verify, merge, report. You do
 not do the lanes' work — if you catch yourself editing a lane's code mid-flight,
 stop and fix the goal file or relaunch instead.
 
-Every rule here was bought with a real failure across ~33 lanes of production
-use. **The rules are field-tested; this file's exact sequencing is not — it has
-driven few batches. Report what breaks.**
+Every rule here was bought with a real failure in production use — roughly 45
+lanes across three operators. Where a rule looks fussy, it is load-bearing.
 
 Shape references (plan screen, approval vocabulary, DONE.json, report) live in
 `examples/plan-and-report.md`. This file is the rules.
@@ -42,13 +42,21 @@ goal-batch skill and …"** in natural language — both load this skill reliabl
 itself, producing plausible branches with no gate, no manifest, and no lanes.
 Name the skill, or call `load_skill(skill_name="goal-batch", arguments=…)`.
 
+**If `$ARGUMENTS` is empty, you have no batch.** This skill forks — the
+sub-session cannot see the parent conversation, so an `arguments`-less
+`load_skill` call arrives with nothing to plan against. That happened in a real
+run and the whole invocation died silently. Do not produce an empty plan and do
+not guess: reconstruct the batch from whatever context you were given, and if
+there genuinely is none, say so in one line and ask for the work. One question,
+not an interview.
+
 **Running the companion scripts.** `load_skill` returns `skill_directory`.
 Resolve every script from it — `<skill_directory>/scripts/<name>.sh` — and use
 that absolute path. Never a bare relative path: the working directory is the
-target repo, not the skill, and once this ships in a bundle the skill lives
-under a hash-suffixed cache path that changes. **Never copy a script into the
-target repo** — a real run did exactly that, leaving `.amplifier/bin/` behind as
-untracked pollution in someone else's repository.
+target repo, not the skill, and in a bundle the skill lives under a
+hash-suffixed cache path that changes between installs. **Never copy a script
+into the target repo** — a real run did exactly that, leaving `.amplifier/bin/`
+behind as untracked pollution in someone else's repository.
 
 **Input** — `$ARGUMENTS`: the work to batch, or a pointer to where it is
 enumerated. If lane independence is unclear, that is Phase 1's job, not a
@@ -79,22 +87,50 @@ No lane cap. Width is bounded by the work.
 
 ## Phase 2 — Review and go
 
-**The one mandatory stop. Nothing is created and nothing launches before the
-user says go.**
+**Nothing is created and nothing launches before the user has seen the plan.**
 
-Show the plan on one screen — lane table, contested files, parked items, unowned
-files, per-lane time bound, watching mode. Fifteen seconds to read, one sentence
-to argue with. Shape in `examples/`.
+**Open with what the batch will NOT deliver.** The first two lines are:
+
+```
+When this finishes you WILL have: <the concrete end state>
+You will NOT have:                <what stays undone, and what it blocks>
+```
+
+This is the whole point of the gate and the one thing it has actually failed at.
+In a real run the fact that the batch *would not produce a working component*
+was disclosed — as the third bullet, inside a code block, under a heading about
+testing — and the user found out only after it finished: *"So the batch had post
+work associated with it? That was not clear to me."* Anything a reader would be
+upset to discover afterwards goes in line two, not in a section they will skim.
+
+Then the plan on one screen — lane table, contested files, parked items, unowned
+files, per-lane bounds, watching mode. Fifteen seconds to read, one sentence to
+argue with. Shape in `examples/`.
 
 Ask questions ONLY where a wrong guess costs a relaunch: an ownership call you
 cannot make from the code, a repo you are not sure you may push to, a
 human-reserved action. Bring a plan, not a form.
 
+**Every lane must trace to something the user asked for.** State the origin of
+each lane in the table. A run once invented a lane out of the orchestrator's own
+scratch notes and got 32 minutes into the gate before the user caught it:
+*"Lane F drafts five upstream feature requests against repos we don't own."
+What? Why are we changing other repos?* If you cannot name where a lane came
+from, it is not a lane.
+
 **Approval is conversational.** Accept a bare `go`, and accept a `go` carrying
-options — reporting cadence, per-lane time bounds, dropping a lane — and honor
-them without re-asking. Anything that is not an affirmative is feedback: revise,
-show the diff, re-present the gate. Never infer approval from enthusiasm,
-repetition, or silence.
+options — reporting cadence, per-lane bounds, dropping a lane — and honor them
+without re-asking. Anything that is not an affirmative is feedback: revise, show
+the diff, re-present. Never infer approval from enthusiasm, repetition, or
+silence.
+
+**Pre-authorization is valid and must be honored.** If the invocation itself
+grants approval — "pre-approved", "don't stop and ask", "go ahead and run it" —
+post the plan for the record and proceed without waiting. Users have started
+pre-arguing with the gate in the same breath as the request (*"but do NOT bug me
+about this simple design, then launch into /goal-batch"*), and the cleanest run
+in the field skipped the gate entirely. The plan is always shown; stopping is
+what a user may waive. Waiving is theirs to do, never yours to assume.
 
 ## Phase 3 — Compose the goal files
 
@@ -133,10 +169,17 @@ Every goal carries:
   shared services are read-only evidence to a lane; tests use fixtures.
 - **The time bound**, and that exceeding it is a terminal `BUDGET` state, not a
   reason to rush the work or skip the commit.
+- **Add `DONE.json` to the repo's `.gitignore` before writing it.** Four of five
+  lanes in one run committed theirs and the batch's own merge pass collided on
+  that file. It is a signal, not an artifact.
 - **Write `DONE.json` in the worktree root as your final act** — the terminal
   marker. Without it, an exited session is indistinguishable from a killed one.
-  Fields: `lane, verdict, branch, head, pushed, items[], residuals[],
-  pending_human[], suite`. Shape in `examples/`.
+  Fields: `lane, session_id, verdict, branch, head, pushed, items[],
+  residuals[], pending_human[], suite`. Shape in `examples/`.
+  **`verdict` is exactly one of `COMPLETE` / `BLOCKED` / `PARTIAL`**, and
+  `session_id` is this lane's own — two lanes in one batch wrote `"PASS"` and
+  `"success"`, which no parser reads the same way, and a `DONE.json` without a
+  session_id cannot be told apart from one inherited through the base commit.
 - **KNOWN section** — env setup, suite commands, baselines, footguns. Speed
   aid, not criteria.
 
@@ -160,19 +203,32 @@ their activity becomes unattributable.
 
 ## Phase 5 — Launch and register
 
-One tmux session per lane, via the companion script:
+One tmux session per lane, via the companion script — once per lane:
 
 ```bash
-scripts/launch_lane.sh <lane> <worktree> .amplifier/goals/<lane>.md \
-                       gb__<batch>__<lane> /tmp/gb-<batch>-<lane>.log [timeout_s]
+<skill_directory>/scripts/launch_lane.sh \
+    <batch> <lane> <worktree> .amplifier/goals/<lane>.md \
+    <repo>/.amplifier/goals/manifest.tsv [wall_s] [max_turns]
 ```
 
-It prints a manifest row and enforces four things you must not reimplement by
-hand: the tmux command contains **no user prose** (a lone apostrophe in a launch
-note silently truncated a real launch — put launch notes INSIDE the goal file);
-logging survives; the lane is wrapped in `timeout` in its own process group so a
-runaway dies with its children; and it **fails loud** if no session ID appears,
-rather than writing a blank into the crash anchor.
+**The script owns the manifest. Never hand-write it.** It writes the header on
+first call and appends one 8-column row per lane. Both users of v1 ended up
+hand-writing manifests because the launcher emitted 5 columns while the status
+probe read 7 — they never agreed, and no batch could use both tools as shipped.
+If you find yourself composing a `manifest.tsv` heredoc, stop: something is
+wrong and hand-writing it will hide the failure.
+
+The tmux session name and log path are **derived** from `<batch>`/`<lane>`, so
+the `gb__*` convention that the orphan sweep and pane-viewer match strings depend
+on cannot drift.
+
+It also enforces five things you must not reimplement by hand: the tmux command
+carries **no user prose** (a lone apostrophe in a launch note silently truncated
+a real launch — put launch notes INSIDE the goal file); logging survives; the
+lane runs under `timeout` in its own process group so a runaway dies with its
+children; any inherited `DONE.json` is purged before launch; and it **fails
+loud** if no session ID appears rather than writing a blank into the crash
+anchor.
 
 One-phase launch is mandatory. Never start a bare `amplifier` TUI and `send-keys`
 the `/goal` into it — keystrokes sent to a busy pane get swallowed silently (one
@@ -198,30 +254,52 @@ reconstruct the batch; without it, recovery was 40 minutes of archaeology.
 
 ## Phase 6 — Watch
 
-Load **monitor** for the polling discipline — it owns the SEQUENTIAL-ONLY rule
-and the batched-imposter check. Delegate the loop per its Step 3 and give it
-this batch's instrument:
+**Every claim you make about a lane must come from a probe you just ran.** This
+is the rule; everything below serves it. Watchers that narrated from memory or
+from a pane's last line have fabricated in multiple runs — one declared
+`TIMEOUT: reached 95-minute max duration` at 30 minutes actual, and one reported
+`No DONE.json files written` 68 seconds before the merge collided with those
+exact files. The run with the lowest overhead measured (7% of spend) is the one
+that probed for everything it said.
+
+The instrument:
 
 ```bash
-scripts/batch_status.sh <manifest.tsv> <BASE_SHA>     # one line per lane, ~8ms each
-SHOW_LAST=1 scripts/batch_status.sh <manifest.tsv>    # + last 3 turns per lane
+<skill_directory>/scripts/batch_status.sh <manifest.tsv> <BASE_SHA>
+SHOW_LAST=1 <skill_directory>/scripts/batch_status.sh <manifest.tsv>
 ```
 
-**Monitors lied in every prior run because they were reading `tail -1` of a
-TUI.** Give the watcher a real instrument and its job becomes mechanical. Three
-signals are counter-intuitive and the script exists to encode them:
+Its first line is `BATCH_ELAPSED`, computed from the manifest header — **that is
+the only elapsed time that means anything.** The per-lane `LANE_IDLE` column is
+seconds since that lane last emitted an event; reading it as batch elapsed time
+is what killed a watch an hour early.
 
+Five signals are counter-intuitive and the script encodes them so you do not
+have to reason about them:
+
+- Terminal is `DONE.json`, checked against the manifest's session_id — an
+  inherited one from the base commit otherwise reads as a finished lane.
+- Alive is `kill -0` on the lane PID, **not** tmux presence. The tmux server has
+  died mid-batch in three separate runs, leaving healthy lanes running as
+  orphans while tmux-keyed probes went blind.
 - Liveness is `events.jsonl` mtime, **not** `transcript.jsonl` mtime — the
-  transcript freezes completely while a lane delegates to a sub-agent.
-- Progress is assistant turns counted from the transcript, **not**
+  transcript freezes entirely while a lane delegates to a sub-agent.
+- Progress is assistant turns from the transcript, **not**
   `metadata.turn_count`, which is corrupt (reports 1 for a 21-turn session).
 - Pushed is `git ls-remote`, **not** `@{upstream}`, never set by an
   explicit-refspec push.
 
+**Wait on state change, not on a clock.** Sleep between probes; do not spend a
+model call to decide whether to sleep again. In one run 51 of 70 monitor calls
+were bare `sleep`, and monitoring ran 3.9× longer than the work it watched.
+Load **monitor** if you delegate the loop — it owns the SEQUENTIAL-ONLY rule and
+the batched-imposter check — but the loop's job here is mechanical: probe,
+compare, sleep, repeat.
+
 Report per the mode approved in Phase 2. Interrupt regardless for: a lane
-`DIED`, a lane asking a human a question, or the probe itself failing twice.
-Stall thresholds (120s/900s) are starting guesses — calibrate before letting
-`STALLED` justify killing anything.
+`DIED`, a `STALE-DONE-IGNORED` verdict, a lane asking a human a question, or the
+probe itself failing twice. Stall thresholds (120s/900s) are starting guesses —
+calibrate before letting `STALLED` justify killing anything.
 
 **Verify the watcher's verdict yourself before acting on it.** Both false-DONE
 and false-crash have happened.

--- a/skills/goal-batch/scripts/batch_status.sh
+++ b/skills/goal-batch/scripts/batch_status.sh
@@ -1,33 +1,32 @@
 #!/usr/bin/env bash
 # batch_status.sh <manifest.tsv> [base_sha]
 #
-# One line per lane. This is the instrument the monitor reads.
-# Cost: stat-only liveness, ~8ms per lane. File size is irrelevant --
-# a 750MB events.jsonl costs the same as an empty one.
+# One line per lane. This is the instrument the watcher reads.
+# Reads the 8-column manifest that launch_lane.sh writes. Never hand-write it.
 #
-# Manifest is TSV, one row per lane, comment lines start with '#':
-#   lane <TAB> worktree <TAB> branch <TAB> tmux <TAB> goal <TAB> log <TAB> session_id
+# SHOW_LAST=1  also print each lane's last 3 top-level turns.
 #
-# SHOW_LAST=1  also print the last 3 top-level turns per lane.
+# --- what each signal is, and why NOT the obvious alternative ----------------
+# TERMINAL  = DONE.json in the worktree root, verified against the manifest's
+#             session_id when present. Pane death alone cannot distinguish
+#             "goal satisfied" from "killed".
+# ALIVE     = kill -0 on the lane PID. NOT tmux presence: the tmux server has
+#             died mid-batch in three separate real runs, leaving healthy lanes
+#             running as orphans while a tmux-keyed probe went blind.
+# LIVENESS  = newest events.jsonl mtime in the lane's workspace. NOT
+#             transcript.jsonl mtime, which freezes entirely while a lane
+#             delegates to a sub-agent (measured: 4 live sessions, 124s apart,
+#             zero transcript movement).
+# PROGRESS  = assistant turns counted from the transcript. NOT
+#             metadata.turn_count, which is corrupt (reports 1 for 21 turns).
+# PUSHED    = git ls-remote. NOT @{upstream}, never set by explicit-refspec push.
 #
-# --- signals, and why these and not the obvious ones -------------------------
-# LIVENESS  = newest events.jsonl mtime anywhere in the lane's workspace.
-#   NOT transcript.jsonl mtime. transcript.jsonl only advances on completed
-#   ROOT-LEVEL tool calls, so a lane delegating to a sub-agent for 20 minutes
-#   has a completely frozen transcript. Measured: 4 live sessions sampled 124s
-#   apart showed ZERO transcript movement, including one blocked inside a single
-#   delegate call. events.jsonl mtime tracked wall clock (+76s/+80s over 78s).
-# PROGRESS  = assistant turns counted from the transcript.
-#   NOT metadata.turn_count -- it is corrupt. Observed: turn_count=1 on a
-#   session with 21 assistant turns; turn_count=40 on one with 348.
-# PUSHED    = git ls-remote.
-#   NOT @{upstream} -- `git push origin <branch>` sets no tracking config, so a
-#   pushed branch reads as never-pushed.
-# TERMINAL  = DONE.json written by the lane as its final act.
-#   Pane death alone cannot distinguish "goal satisfied" from "killed".
+# BATCH_ELAPSED comes from the manifest header, NOT from any lane's idle timer.
+# A watcher once read a lane's idle seconds as batch elapsed time and killed the
+# watch at 30 minutes claiming 95. The per-lane column is named LANE_IDLE so the
+# two can never be confused again.
 #
 # Requires GNU find (-printf), jq, git, tmux.
-# -----------------------------------------------------------------------------
 
 set -uo pipefail
 
@@ -38,29 +37,59 @@ WARM="${GOAL_BATCH_WARM:-120}"    # idle < WARM -> WORKING
 COLD="${GOAL_BATCH_COLD:-900}"    # idle < COLD -> SLOW, else STALLED
 CI_BASE="${AMPLIFIER_CONTEXT_INTELLIGENCE_BASE_PATH:-$HOME/.amplifier/projects}"
 
+[ -s "$MAN" ] || { echo "FATAL: manifest missing or empty: $MAN" >&2; exit 2; }
 mkdir -p "$STATE"
 NOW=$(date +%s)
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-printf '%-14s %-19s %-8s %-10s %-8s %-6s %-7s %s\n' \
-  LANE VERDICT IDLE TURNS COMMITS DIRTY PUSHED BRANCH
+# --- batch-level elapsed, from the manifest header ---------------------------
+LAUNCHED=$(sed -n 's/.*launched_at=\([0-9]*\).*/\1/p' "$MAN" | head -1)
+if [ -n "${LAUNCHED:-}" ]; then
+  E=$(( NOW - LAUNCHED ))
+  printf 'BATCH_ELAPSED %02d:%02d:%02d   manifest=%s\n' $((E/3600)) $((E%3600/60)) $((E%60)) "$MAN"
+else
+  printf 'BATCH_ELAPSED unknown (manifest header has no launched_at)   manifest=%s\n' "$MAN"
+fi
 
-while IFS=$'\t' read -r lane wt branch tmuxname goal log sid; do
+printf '%-14s %-19s %-10s %-10s %-8s %-6s %-7s %s\n' \
+  LANE VERDICT LANE_IDLE TURNS COMMITS DIRTY PUSHED BRANCH
+
+while IFS=$'\t' read -r lane wt branch tmuxname goal log sid pid; do
   case "${lane:-}" in ''|'#'*) continue ;; esac
 
-  done_json=no
-  [ -f "$wt/DONE.json" ] && done_json=yes
+  # --- terminal marker, guarded against a stale/inherited file ---------------
+  done_state=no
+  if [ -f "$wt/DONE.json" ]; then
+    done_sid=$(jq -r '.session_id // empty' "$wt/DONE.json" 2>/dev/null)
+    if [ -n "$done_sid" ] && [ -n "${sid:-}" ] && [ "$done_sid" != "$sid" ]; then
+      done_state=stale
+    else
+      done_state=yes
+    fi
+  fi
 
-  # --- liveness (stat only, never a read) ------------------------------------
+  # --- verdict normalisation: the enum drifted across lanes in one real batch
+  verdict_field=""
+  if [ "$done_state" = yes ]; then
+    verdict_field=$(jq -r '(.verdict // "") | ascii_upcase' "$wt/DONE.json" 2>/dev/null)
+    case "$verdict_field" in
+      COMPLETE|PASS|SUCCESS|OK|DONE) verdict_field=COMPLETE ;;
+      BLOCKED)                       verdict_field=BLOCKED ;;
+      PARTIAL)                       verdict_field=PARTIAL ;;
+      "")                            verdict_field=COMPLETE ;;
+      *)                             verdict_field="ODD:$verdict_field" ;;
+    esac
+  fi
+
+  # --- liveness (stat only, never a read) -----------------------------------
   slug="$(printf '%s' "$wt" | tr '/' '-')"
   ws="$CI_BASE/$slug/sessions"
-  newest=$(find "$ws" -maxdepth 2 -name events.jsonl -printf '%T@\n' 2>/dev/null \
-           | sort -rn | head -1)
+  newest=$(find "$ws" -maxdepth 2 -name events.jsonl -printf '%T@\n' 2>/dev/null | sort -rn | head -1)
   newest="${newest%%.*}"
   if [ -n "${newest:-}" ]; then idle=$(( NOW - newest )); idle_s="${idle}s"
   else                          idle=-1;                 idle_s="n/a"; fi
 
-  # --- progress --------------------------------------------------------------
+  # --- progress -------------------------------------------------------------
   turns='-'
   tr_file="$ws/${sid:-__none__}/transcript.jsonl"
   if [ -f "$tr_file" ]; then
@@ -70,7 +99,7 @@ while IFS=$'\t' read -r lane wt branch tmuxname goal log sid; do
     turns="${n}+$(( n - prev ))"
   fi
 
-  # --- git facts -------------------------------------------------------------
+  # --- git facts ------------------------------------------------------------
   if [ -d "$wt" ]; then
     dirty=$(git -C "$wt" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
     if [ -n "$BASE_SHA" ]; then
@@ -83,23 +112,29 @@ while IFS=$'\t' read -r lane wt branch tmuxname goal log sid; do
     dirty='-'; commits='-'; pushed='-'
   fi
 
+  # --- alive: PID first, tmux only as corroboration -------------------------
   alive=no
-  tmux has-session -t "$tmuxname" 2>/dev/null && alive=yes
-
-  # --- verdict (precedence matters; liveness only applies while alive) --------
-  if   [ ! -d "$wt" ];                                                    then v=WORKTREE-MISSING
-  elif [ "$done_json" = yes ] && [ "$dirty" != 0 ];                       then v=LANDED-DIRTY
-  elif [ "$done_json" = yes ] && [ "$pushed" = 0 ];                       then v=LANDED-NOT-PUSHED
-  elif [ "$done_json" = yes ];                                            then v=LANDED
-  elif [ "$alive" = yes ] && [ "$idle" -lt 0 ];                           then v=STARTING
-  elif [ "$alive" = yes ] && [ "$idle" -lt "$WARM" ];                     then v=WORKING
-  elif [ "$alive" = yes ] && [ "$idle" -lt "$COLD" ];                     then v=SLOW
-  elif [ "$alive" = yes ];                                                then v=STALLED
-  elif [ "$idle" -lt 0 ];                                                 then v=NOT-STARTED
-  else                                                                         v=DIED
+  if [ -n "${pid:-}" ] && [ "$pid" != "-" ] && kill -0 "$pid" 2>/dev/null; then
+    alive=yes
+  elif tmux has-session -t "$tmuxname" 2>/dev/null; then
+    alive=yes
   fi
 
-  printf '%-14s %-19s %-8s %-10s %-8s %-6s %-7s %s\n' \
+  # --- verdict (precedence matters) -----------------------------------------
+  if   [ ! -d "$wt" ];                                        then v=WORKTREE-MISSING
+  elif [ "$done_state" = stale ];                             then v=STALE-DONE-IGNORED
+  elif [ "$done_state" = yes ] && [ "$dirty" != 0 ];          then v="${verdict_field}-DIRTY"
+  elif [ "$done_state" = yes ] && [ "$pushed" = 0 ];          then v="${verdict_field}-NOT-PUSHED"
+  elif [ "$done_state" = yes ];                               then v="$verdict_field"
+  elif [ "$alive" = yes ] && [ "$idle" -lt 0 ];               then v=STARTING
+  elif [ "$alive" = yes ] && [ "$idle" -lt "$WARM" ];         then v=WORKING
+  elif [ "$alive" = yes ] && [ "$idle" -lt "$COLD" ];         then v=SLOW
+  elif [ "$alive" = yes ];                                    then v=STALLED
+  elif [ "$idle" -lt 0 ];                                     then v=NOT-STARTED
+  else                                                             v=DIED
+  fi
+
+  printf '%-14s %-19s %-10s %-10s %-8s %-6s %-7s %s\n' \
     "$lane" "$v" "$idle_s" "$turns" "$commits" "$dirty" "$pushed" "$branch"
 
   if [ "${SHOW_LAST:-0}" = 1 ] && [ -f "$tr_file" ]; then

--- a/skills/goal-batch/scripts/launch_lane.sh
+++ b/skills/goal-batch/scripts/launch_lane.sh
@@ -1,73 +1,104 @@
 #!/usr/bin/env bash
-# launch_lane.sh <lane> <worktree> <goal-file> <tmux-name> <log> [wall_s] [max_turns]
+# launch_lane.sh <batch> <lane> <worktree> <goal-rel-path> <manifest> [wall_s] [max_turns]
 #
-#   goal-file  path RELATIVE TO THE WORKTREE. It must be committed to the base
-#              commit before `git worktree add`, so every worktree contains it.
-#   wall_s     wall-clock bound, default 7200. 0 disables.
-#   max_turns  turn bound passed to /goal, default 0 (unlimited, per ADR-0005).
+#   batch/lane     name the batch and the lane. tmux session and log path are
+#                  DERIVED from them -- gb__<batch>__<lane> and
+#                  /tmp/gb-<batch>-<lane>.log -- so the naming convention that
+#                  the orphan sweep and pane-viewer match strings depend on
+#                  cannot drift.
+#   goal-rel-path  path RELATIVE TO THE WORKTREE. Must be committed to the base
+#                  commit before `git worktree add`, so every worktree has it.
+#   manifest       the batch manifest. THIS SCRIPT OWNS IT: it writes the header
+#                  on first call and appends one row per lane. Nothing else
+#                  should ever write it by hand.
+#   wall_s         wall-clock bound, default 7200. 0 disables.
+#   max_turns      turn bound passed to /goal, default 0 (unlimited, ADR-0005).
+#                  NOTE: --max-turns is parsed by /goal, NOT by `amplifier run`,
+#                  so it rides inside the prompt string.
 #
-# Prints one manifest TSV row on success:  lane  worktree  tmux  log  session_id
+# MANIFEST SCHEMA (8 columns, tab-separated) -- batch_status.sh reads exactly this:
+#   lane  worktree  branch  tmux  goal  log  session_id  pid
 #
-# Four structural properties, each fixing a measured failure:
-#
-# 1. NO USER PROSE IN THE SHELL STRING. The tmux command carries only a
-#    fixed-shape path, validated for metacharacters. Launch notes go INSIDE the
-#    goal file. A lone apostrophe in a launch note silently truncated a real
-#    launch; this makes that unrepresentable rather than warned about.
-# 2. LOGGING SURVIVES. `tee` runs inside the wrapper, so the log that the
-#    manifest, the session-ID harvest and crash recovery all depend on exists.
-# 3. BOUNDED, AND THE WHOLE TREE DIES. `timeout` bounds wall-clock; an EXIT trap
-#    signals the entire process group, so a bounded-out lane does not leave
-#    orphaned children behind (plain `timeout` signals only its direct child).
-#    `--max-turns` bounds turns -- note it is parsed by /goal, NOT by
-#    `amplifier run`, so it goes INSIDE the prompt string.
-# 4. FAILS LOUD on no session ID rather than writing a blank into the manifest,
-#    which is the crash anchor and gets trusted during recovery.
+# v2 changes, each bought with a measured failure in real team use:
+#  - Owns the manifest end-to-end. v1 emitted 5 columns while batch_status.sh
+#    read 7; the two never agreed, and every real user hand-wrote the manifest
+#    to work around it.
+#  - Records the lane PID. tmux servers have died mid-batch in three separate
+#    runs; PID liveness keeps the status probe working when tmux is gone.
+#  - Purges any inherited DONE.json before launch. A DONE.json carried in
+#    through the base commit reads as an already-finished lane.
+#  - `setsid --wait`. Bare `setsid` launched ZERO of five lanes on another
+#    operator's machine while working fine here.
 
 set -uo pipefail
 
-LANE="${1:?lane}"; WT="${2:?worktree}"; GOAL="${3:?goal-file (relative to worktree)}"
-TMUXNAME="${4:?tmux-name}"; LOG="${5:?log}"; WALL="${6:-7200}"; MAXTURNS="${7:-0}"
+BATCH="${1:?batch name}"; LANE="${2:?lane name}"; WT="${3:?worktree}"
+GOAL="${4:?goal path relative to worktree}"; MANIFEST="${5:?manifest path}"
+WALL="${6:-7200}"; MAXTURNS="${7:-0}"
 
+TMUXNAME="gb__${BATCH}__${LANE}"
+LOG="/tmp/gb-${BATCH}-${LANE}.log"
+PIDFILE="/tmp/gb-${BATCH}-${LANE}.pid"
+
+# --- preflight: fail loud, never launch degraded ------------------------------
 [ -d "$WT" ] || { echo "FATAL $LANE: worktree missing: $WT" >&2; exit 2; }
 [ -f "$WT/$GOAL" ] || {
   echo "FATAL $LANE: goal file not in worktree: $WT/$GOAL" >&2
   echo "  Goal files must be COMMITTED to the base commit before 'git worktree add'." >&2
   exit 2; }
-
-case "$GOAL" in
-  *[\'\"\ \$\`\\]*) echo "FATAL $LANE: goal path has shell metachars: $GOAL" >&2; exit 2 ;;
-esac
-case "$MAXTURNS" in ''|*[!0-9]*) echo "FATAL $LANE: max_turns must be a non-negative integer: $MAXTURNS" >&2; exit 2 ;; esac
+case "$GOAL" in *[\'\"\ \$\`\\]*)
+  echo "FATAL $LANE: goal path has shell metachars: $GOAL" >&2; exit 2 ;; esac
+case "$BATCH$LANE" in *[!a-zA-Z0-9-]*)
+  echo "FATAL: batch/lane must be [a-zA-Z0-9-] only (got '$BATCH'/'$LANE')" >&2; exit 2 ;; esac
+case "$MAXTURNS" in ''|*[!0-9]*)
+  echo "FATAL $LANE: max_turns must be a non-negative integer: $MAXTURNS" >&2; exit 2 ;; esac
 
 if tmux has-session -t "$TMUXNAME" 2>/dev/null; then
   echo "SKIP $LANE: tmux session '$TMUXNAME' already live (not clobbering)"
   exit 3
 fi
 
+# The lane runs under a non-login shell inside tmux. `amplifier` living only on a
+# login-shell PATH is the difference between a clean abort here and a 60-second
+# wait for a Session ID that can never arrive.
+AMP="$(command -v amplifier || true)"
+if [ -z "$AMP" ]; then
+  AMP="$(bash -lc 'command -v amplifier' 2>/dev/null || true)"
+  [ -n "$AMP" ] || { echo "FATAL $LANE: 'amplifier' not on PATH (checked plain and login shell)." >&2; exit 2; }
+  echo "NOTE $LANE: amplifier only on the login PATH; pinning $AMP" >&2
+fi
+
+BRANCH=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')
+
+# A DONE.json inherited from the base commit means "finished" to every reader.
+rm -f "$WT/DONE.json" "$PIDFILE"
+
 # /goal parses a LEADING --max-turns; 0 means unlimited, so omit it entirely.
 if [ "$MAXTURNS" -gt 0 ]; then PROMPT="/goal --max-turns ${MAXTURNS} @${GOAL}"
 else                           PROMPT="/goal @${GOAL}"; fi
 
-# Wrapper file: keeps quoting out of the tmux command line, and owns the
-# process-group cleanup that plain `timeout` does not do.
-WRAP="$(mktemp "/tmp/gb-wrap-${LANE}-XXXXXX.sh")"
+# Wrapper keeps quoting off the tmux command line and owns process-group cleanup
+# that plain `timeout` does not do (it signals only its direct child).
+WRAP="$(mktemp "/tmp/gb-wrap-${BATCH}-${LANE}-XXXXXX.sh")"
 {
   echo '#!/usr/bin/env bash'
+  printf 'echo $$ > %q\n' "$PIDFILE"
   echo 'trap '\''kill -- -$$ 2>/dev/null'\'' EXIT'
   if [ "$WALL" -gt 0 ]; then
-    printf 'timeout --signal=TERM --kill-after=60s %ss amplifier run %q 2>&1 | tee %q\n' \
-           "$WALL" "$PROMPT" "$LOG"
+    printf 'timeout --signal=TERM --kill-after=60s %ss %q run %q 2>&1 | tee %q\n' \
+           "$WALL" "$AMP" "$PROMPT" "$LOG"
   else
-    printf 'amplifier run %q 2>&1 | tee %q\n' "$PROMPT" "$LOG"
+    printf '%q run %q 2>&1 | tee %q\n' "$AMP" "$PROMPT" "$LOG"
   fi
   printf 'echo "LANE_EXIT=${PIPESTATUS[0]} $(date -Is)" >> %q\n' "$LOG"
 } > "$WRAP"
 chmod +x "$WRAP"
 
-tmux new-session -d -s "$TMUXNAME" -c "$WT" "setsid $WRAP"
+tmux new-session -d -s "$TMUXNAME" -c "$WT" "setsid --wait $WRAP"
 
-# --- harvest the session ID, FAIL LOUD if it never appears -------------------
+# --- harvest the session ID; FAIL LOUD if it never appears --------------------
+# The manifest is the crash anchor. A blank ID in it is worse than no manifest,
+# because recovery will trust it.
 SID=""
 for _ in $(seq 1 24); do            # up to ~60s for a cold start
   sleep 2.5
@@ -83,4 +114,16 @@ if [ -z "$SID" ]; then
   exit 4
 fi
 
-printf '%s\t%s\t%s\t%s\t%s\n' "$LANE" "$WT" "$TMUXNAME" "$LOG" "$SID"
+PID=$(cat "$PIDFILE" 2>/dev/null || echo '-')
+
+# --- write the manifest (header once, then one row per lane) ------------------
+if [ ! -s "$MANIFEST" ]; then
+  mkdir -p "$(dirname "$MANIFEST")"
+  {
+    printf '# lane\tworktree\tbranch\ttmux\tgoal\tlog\tsession_id\tpid\n'
+    printf '# batch=%s launched_at=%s wall_s=%s max_turns=%s\n' \
+           "$BATCH" "$(date +%s)" "$WALL" "$MAXTURNS"
+  } > "$MANIFEST"
+fi
+printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+  "$LANE" "$WT" "$BRANCH" "$TMUXNAME" "$GOAL" "$LOG" "$SID" "$PID" | tee -a "$MANIFEST"


### PR DESCRIPTION
goal-batch v2.0.0. Five days of real team use (3 operators, ~45 lanes) surfaced defects that a single-operator proving run structurally could not catch. Every change below traces to a specific observed failure.

## SCRIPT FIXES (mechanisms, not guidance)

- **launch_lane.sh now OWNS the manifest end-to-end** — writes the header and appends one 8-column row per lane. v1 emitted 5 columns while batch_status.sh read 7; the two never agreed, so no batch could actually use both tools as shipped. Both real users independently hand-wrote manifests to work around it.

- **Manifest now records the lane PID.** batch_status.sh determines liveness from `kill -0 <pid>` first, tmux only as corroboration. The tmux server has died mid-batch in three separate runs, leaving healthy lanes running as orphans while tmux-keyed probes went blind.

- **launch_lane.sh purges any inherited DONE.json** before launch, and batch_status.sh cross-checks DONE.json's session_id against the manifest — reporting STALE-DONE-IGNORED on mismatch. A DONE.json carried in through the base commit otherwise reads as an already-finished lane.

- **`setsid --wait`** (was bare `setsid`) — bare setsid launched ZERO of five lanes on another operator's machine while working here.

- **launch_lane.sh resolves `amplifier` via plain PATH then login PATH,** pins the absolute path into the wrapper, and aborts immediately with a clear message if unresolvable. Previously a non-login-shell PATH produced a confusing 60-second wait for a Session ID that could never arrive.

- **batch_status.sh prints BATCH_ELAPSED** from the manifest header and renames the per-lane column to LANE_IDLE. A watcher read lane idle-seconds as batch elapsed time and terminated a watch at 30 minutes actual while claiming 95.

- **batch_status.sh normalizes the DONE.json verdict enum.** Two lanes in one batch wrote "PASS" and "success"; no parser reads those the same way.

- **tmux session name and log path are now DERIVED from batch/lane,** so the gb__* convention the orphan sweep and pane-viewer match strings depend on cannot drift.

## SKILL.md CHANGES

- Phase 2 gate now opens with what the batch will NOT deliver. In a real run the fact that the batch would not produce a working component was disclosed as the third bullet inside a code block, and the user found out only afterwards.

- Phase 2 requires each lane to trace to something the user asked for. A run invented a lane from the orchestrator's own scratch notes and got 32 minutes into the gate before the user caught it.

- Phase 2 honors explicit pre-authorization: plan is always shown, stopping is what a user may waive.

- Phase 3 requires gitignoring DONE.json before writing it (four of five lanes in one run committed theirs and the merge pass collided on that file), pins the verdict enum to COMPLETE/BLOCKED/PARTIAL, and requires session_id in DONE.json.

- Phase 6 rewritten around evidence-bound monitoring: every claim about a lane must come from a probe just run; wait on state change, not on a clock. The lowest-overhead run measured (7% of spend) probed for everything it said; watchers that narrated from memory fabricated in multiple runs.

- Handles empty $ARGUMENTS explicitly — a fork-skill invocation without arguments silently killed a real run.

- Added `version: 2.0.0` to frontmatter.

## VERIFICATION (all run, not asserted)

- 7 local tests pass: crossed manifest pipe, stale-DONE detection, tmux-death survival, verdict enum normalization across 5 inputs, idempotent relaunch, dead-lane detection, guard rejections.

- DTU end-to-end with two REAL amplifier lanes: launch_lane.sh wrote the manifest, batch_status.sh read it correctly (the seam that was broken in v1), a seeded stale DONE.json was purged, `tmux kill-server` was executed mid-run and both lanes continued to report WORKING via PID, both reached COMPLETE with matching session_ids, both branches pushed to a real remote, zero DONE.json tracked in any commit, full teardown clean.

## KNOWN

SKILL.md grew 258 → 336 lines. Every addition traces to a measured failure, but length is worth watching on the next revision.