### PR TITLE
fix: goal-batch — stop requiring a git remote, and correct the misattributed failure behind it

### DIFF
--- a/skills/goal-batch/SKILL.md
+++ b/skills/goal-batch/SKILL.md
@@ -40,7 +40,10 @@ goal-batch skill and …"** in natural language — both load this skill reliabl
 (measured). What does NOT work is a bare `/goal-batch …` in a headless
 `amplifier run "<prompt>"`: the model reads the token as prose and does the work
 itself, producing plausible branches with no gate, no manifest, and no lanes.
-Name the skill, or call `load_skill(skill_name="goal-batch", arguments=…)`.
+In a headless one-shot, **direct the assistant in natural language** — e.g.
+`amplifier run "Use the goal-batch skill and run this batch: …"` — or call
+`load_skill(skill_name="goal-batch", arguments=…)` outright. Naming the skill
+is what loads it; the bare slash token is not.
 
 **If `$ARGUMENTS` is empty, you have no batch.** This skill forks — the
 sub-session cannot see the parent conversation, so an `arguments`-less
@@ -187,10 +190,21 @@ Every goal carries:
 
 Fail loud here. Never launch degraded.
 
-- **Every lane repo has a reachable remote.** `git remote -v` plus a dry push. A
-  lane with no remote is a lane whose work dies with the folder — one real run
-  produced 47MB of genuine output into a remoteless repo and landed nothing in
-  git. A waiver is the user's to give, in writing.
+- **Every lane's output must be COMMITTABLE — not necessarily pushable.** A
+  local-only repo is fine: a lane commits to its own branch, and those commits
+  live in the main repo's object store, so they survive `git worktree remove`
+  and merge normally with no network at all. Verify that, not a remote.
+  - **A remote is recommended, not required.** With one, lanes push as they
+    commit and a crash costs minutes; without one, the work is still safe on
+    disk but only on this machine. Say which the user is getting, once, and
+    move on — do not block the batch.
+  - **What actually loses work is output that is never committed at all.** The
+    real 47MB loss came from a repo that *had* two remotes: the lane's entire
+    output sat under gitignored paths, so it was never committed and pushing
+    would have saved none of it. So check the thing that matters: will each
+    lane's deliverables land in a commit? If a lane's real product is a
+    gitignored artifact directory, say so at the gate — that is a batch that
+    cannot deliver, and no remote fixes it.
 - **Smoke-test the launcher once**, ~90s, thrown away, and confirm any
   capability a lane depends on is reachable from inside a lane.
 - **Create worktrees**, skipping any that already exist rather than failing on

--- a/skills/goal-batch/SKILL.md
+++ b/skills/goal-batch/SKILL.md
@@ -318,6 +318,18 @@ calibrate before letting `STALLED` justify killing anything.
 **Verify the watcher's verdict yourself before acting on it.** Both false-DONE
 and false-crash have happened.
 
+**Inherited artifacts are the single biggest source of false signals.** A lane's
+worktree starts as a full copy of the base commit, so every status file, every
+evidence directory, every `BLOCKED.md` that was already tracked appears to
+belong to the lane. Three false alarms in one day came from this: a `BLOCKED.md`
+byte-identical to main — *whose first line read "The lane is not blocked"* —
+read as a real block; "23 evidence files, great progress" where 20 were
+inherited; a monitor citing a device transcript that shipped with the branch.
+Before reading any artifact as a lane's own output, prove the lane wrote it:
+compare against the base commit (`git log <BASE_SHA>..HEAD -- <path>`, or a
+checksum against base). `launch_lane.sh` purges `DONE.json` for exactly this
+reason; every other artifact is on you.
+
 **Provider rate-limit errors in a pane are healthy, not a stall.** If a lane
 dies of them, that is a model-routing problem: switch the model and relaunch.
 Do not serialize the batch.
@@ -334,7 +346,18 @@ forever. Never let a bounded-out lane vanish silently from the Phase 7 report.
 **Re-verify everything. Lane self-reports are hints.** Two lanes reported green
 honestly from a suite run that predated their own last file.
 
-1. `git fetch`. Diff-stat each landed branch against main.
+1. `git fetch`. Diff-stat each landed branch with **three dots** —
+   `git diff main...HEAD` — not two. Two dots compares against main's *current*
+   tip, so every commit main gained while the lane ran shows up as the lane's
+   work. That produced a near-miss ownership accusation against a lane that had
+   touched none of the files.
+2. **Read the diffs across lanes, not just within them.** File ownership does
+   not catch two lanes inventing the *same* thing at *different* paths — two
+   lanes once created separate `ThreadVisibility` singletons, one written by
+   one lane and read by the other, and **both lanes' tests passed** while the
+   behavior was silently broken. It was caught only by reading the combined
+   diff. Anything that looks like a new shared abstraction deserves a
+   cross-lane look before merging.
 2. Merge **sequentially, ascending by churn, `--no-ff`**. Run the full suite
    yourself after EVERY merge. Verify actual test counts from result files, not
    "BUILD SUCCESSFUL".

--- a/skills/goal-batch/scripts/launch_lane.sh
+++ b/skills/goal-batch/scripts/launch_lane.sh
@@ -68,6 +68,34 @@ if [ -z "$AMP" ]; then
   echo "NOTE $LANE: amplifier only on the login PATH; pinning $AMP" >&2
 fi
 
+# --- lane-environment preflight ----------------------------------------------
+# A lane inherits the TMUX SERVER's environment, not this shell's. When a var
+# the settings interpolate is missing there, it resolves EMPTY -- e.g.
+# `base_url: ${ANTHROPIC_BASE_URL}` becomes "" and every LLM call dies with
+# "Connection error" that looks exactly like a network outage. That killed three
+# lanes twice in one day while the API was reachable the whole time. Refuse to
+# launch rather than die mid-run.
+# Vars are discovered from the settings files, not hardcoded -- a provider this
+# script has never heard of is covered for free.
+if tmux has-session 2>/dev/null || tmux ls >/dev/null 2>&1; then
+  VARS=$(cat ~/.amplifier/settings.yaml .amplifier/settings.yaml 2>/dev/null \
+         | grep -oE '\$\{[A-Z_][A-Z0-9_]*\}' | tr -d '${}' | sort -u)
+  missing=""
+  for v in $VARS; do
+    here="$(printenv "$v" 2>/dev/null || true)"
+    there="$(tmux show-environment -g "$v" 2>/dev/null | sed "s/^$v=//")"
+    case "$there" in "-$v"|"") there="" ;; esac
+    [ -n "$here" ] && [ -z "$there" ] && missing="$missing $v"
+  done
+  if [ -n "$missing" ]; then
+    echo "FATAL $LANE: set in this shell but EMPTY in the tmux server env:$missing" >&2
+    echo "  The lane would inherit empty values and fail with a misleading" >&2
+    echo "  'Connection error' on its first LLM call. Fix, then relaunch:" >&2
+    for v in $missing; do echo "    tmux set-environment -g $v \"\$$v\"" >&2; done
+    exit 2
+  fi
+fi
+
 BRANCH=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')
 
 # A DONE.json inherited from the base commit means "finished" to every reader.
@@ -77,11 +105,43 @@ rm -f "$WT/DONE.json" "$PIDFILE"
 if [ "$MAXTURNS" -gt 0 ]; then PROMPT="/goal --max-turns ${MAXTURNS} @${GOAL}"
 else                           PROMPT="/goal @${GOAL}"; fi
 
+# --- tmux guard: MECHANICAL, because knowledge failed twice -------------------
+# A lane that runs `tmux kill-server` without -L/-S kills the server it is
+# RUNNING IN. tmux resolves -S > -L > $TMUX > TMUX_TMPDIR, and $TMUX is set in
+# every process descended from an attached client -- so TMUX_TMPDIR is NOT
+# isolation. This has happened twice on this class of machine: 73 live sessions
+# destroyed 2026-08-08, 81 more on 2026-08-12. The second lane had the
+# precedence rule documented in its own context when it ran the command.
+# Documentation does not stop this. A shim on the lane's PATH does.
+# Lanes have no legitimate business on the shared server; isolated work must
+# name its socket on EVERY call, including the teardown -- the teardown is the
+# call that bites.
+GUARD_DIR="/tmp/gb-tmux-guard"
+REAL_TMUX="$(command -v tmux || true)"
+if [ -n "$REAL_TMUX" ]; then
+  mkdir -p "$GUARD_DIR"
+  cat > "$GUARD_DIR/tmux" <<GUARD
+#!/usr/bin/env bash
+# Auto-installed by goal-batch launch_lane.sh. Applies to LANES only.
+for a in "\$@"; do
+  case "\$a" in -L|-S|-L*|-S*) exec "$REAL_TMUX" "\$@" ;; esac
+done
+echo "[gb-tmux-guard] REFUSED: tmux invoked without an explicit -L <name> or -S <path>." >&2
+echo "[gb-tmux-guard] TMUX_TMPDIR is NOT isolation -- \\\$TMUX outranks it. That exact" >&2
+echo "[gb-tmux-guard] mistake destroyed 73 live sessions on 2026-08-08 and 81 on 08-12." >&2
+echo "[gb-tmux-guard] Use an isolated socket and pass -L <unique-name> on EVERY call," >&2
+echo "[gb-tmux-guard] including teardown. You are a lane; you do not need the shared server." >&2
+exit 78
+GUARD
+  chmod +x "$GUARD_DIR/tmux"
+fi
+
 # Wrapper keeps quoting off the tmux command line and owns process-group cleanup
 # that plain `timeout` does not do (it signals only its direct child).
 WRAP="$(mktemp "/tmp/gb-wrap-${BATCH}-${LANE}-XXXXXX.sh")"
 {
   echo '#!/usr/bin/env bash'
+  [ -n "$REAL_TMUX" ] && printf 'export PATH=%q:"$PATH"\n' "$GUARD_DIR"
   printf 'echo $$ > %q\n' "$PIDFILE"
   echo 'trap '\''kill -- -$$ 2>/dev/null'\'' EXIT'
   if [ "$WALL" -gt 0 ]; then


### PR DESCRIPTION
Two corrections, both prompted by the skill owner questioning a rule.

## 1. Remote-only gate removed

The preflight gate required every lane repo to have a reachable remote and refused to launch otherwise. That gate blocked a legitimate workflow for a reason that was never true.

**Verified by direct test:** local-only git works through the entire lane lifecycle. A lane commits to its own branch; those commits live in the main repo's object store, so they survive `git worktree remove` intact, remain reachable, and merge normally with no network at all. The only degradation is that batch_status.sh's `pushed` column reads 0 — `git ls-remote` exits nonzero to stderr, it does not crash the probe.

The gate is now: every lane's output must be **COMMITTABLE**, not pushable. A remote is recommended (lanes push as they commit, so a crash costs minutes rather than machine-loss risk) and is stated once, but it never blocks the batch.

## 2. Corrected root cause of actual loss

The justification for the old gate was factually wrong and is corrected in place. The rule cited: "a real run produced 47MB of genuine output into a remoteless repo and landed nothing in git." That repo had TWO remotes configured. The actual loss was that the lane's entire output sat under gitignored paths (`input/`, `originals/`, `clean/`, `runs/`, `decisions/`, `*.log`) — so it was never committed, and pushing would have saved none of it.

The preflight now checks the thing that actually loses work: will each lane's deliverables land in a commit at all? If a lane's real product is a gitignored artifact directory, that is surfaced at the approval gate as a batch that cannot deliver — a condition no remote fixes.

## 3. Clarified headless invocation

In a one-shot `amplifier run`, direct the assistant in natural language ("Use the goal-batch skill and ...") or call load_skill outright. Naming the skill is what loads it; the bare slash token is not.

---

Only SKILL.md changed; script file modes preserved at 100755.
