### PR TITLE
fix: heal read-only .tmp so skill clone doesn't jam forever on Windows

### DIFF
--- a/modules/tool-skills/amplifier_module_tool_skills/_rmtree.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/_rmtree.py
@@ -1,0 +1,123 @@
+"""Robust directory removal for git-checkout cleanup on Windows.
+
+Vendored deliberately, not imported from amplifier-foundation: amplifier-foundation
+is only an OPTIONAL dependency of tool-skills (this module hand-rolls its own git
+clone in ``sources.py`` rather than going through foundation's GitSourceHandler),
+so a runtime import would not be reliably available. The logic is small and
+self-contained; duplicating it is cheaper than taking a hard dependency for a
+single helper. Keep it in sync with ``amplifier_foundation/sources/_rmtree.py``.
+
+Git marks files under ``.git/objects/pack/`` (and occasionally elsewhere,
+e.g. after certain checkouts) read-only. On POSIX, removing a read-only file
+only requires write permission on its *parent* directory, so a plain
+``shutil.rmtree`` succeeds there without any special handling. On Windows,
+the read-only attribute lives on the file itself and blocks the delete
+outright (``PermissionError`` / WinError 5 "Access is denied"), which means
+a cleanup path that calls ``shutil.rmtree`` on a git checkout can fail
+*permanently* on Windows: a failed clone leaves a read-only ``.tmp`` staging
+directory that plain ``shutil.rmtree(..., ignore_errors=True)`` silently
+declines to remove, so every subsequent run finds the same non-empty ``.tmp``
+and git aborts with "destination path already exists and is not an empty
+directory", forever.
+
+``rmtree_robust`` clears the read-only attribute and retries before giving
+up, so cleanup actually heals instead of re-failing identically on every run.
+
+Design note: shutil.rmtree's own ``onexc``/``onerror`` callback is invoked
+per filesystem operation (unlink one file, rmdir one directory, etc.), and
+on some CPython versions a failure that survives a nested callback can
+resurface at a coarser level (e.g. re-reported against ``os.scandir`` for
+the whole directory rather than the one file that actually failed) -- so a
+callback that decides "raise or swallow" per-callback can end up reporting
+a confusing, imprecise error, or in edge cases let a real failure look like
+a no-op success. To keep the failure mode simple and precise regardless of
+those internals, the per-callback handler here always attempts the
+read-only-clear-and-retry and never raises; ``rmtree_robust`` itself then
+checks, once, whether the directory is actually gone -- and raises one
+clear, unambiguous error naming the real path if it is not.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import shutil
+import stat
+import sys
+from pathlib import Path
+
+__all__ = ["rmtree_robust"]
+
+
+def _clear_readonly(path: str) -> None:
+    """Best-effort: add the write bit so a subsequent removal can succeed."""
+    try:
+        current_mode = os.stat(path).st_mode
+    except OSError:
+        return
+    with contextlib.suppress(OSError):
+        os.chmod(path, current_mode | stat.S_IWRITE)
+
+
+def _onexc(function, path, exc) -> None:
+    """onexc/onerror-shaped callback: clear read-only and retry once.
+
+    Never raises -- ``rmtree_robust`` enforces the actual pass/fail contract
+    itself afterward, by checking whether the path still exists. This keeps
+    the per-file callback simple and avoids depending on which exact
+    func/path pairing a given CPython version happens to escalate a nested
+    failure to.
+    """
+    del exc  # unused; callback shape is dictated by shutil.rmtree
+    _clear_readonly(path)
+    with contextlib.suppress(Exception):
+        function(path)
+
+
+def _onerror(function, path, exc_info) -> None:
+    """Adapts the deprecated ``onerror(function, path, exc_info)`` shape
+    (exc_info is a ``sys.exc_info()`` triple) to ``_onexc``."""
+    _onexc(function, path, exc_info[1])
+
+
+def rmtree_robust(path: Path | str, *, ignore_errors: bool = False) -> None:
+    """Remove a directory tree, tolerating Windows read-only files.
+
+    Behaves like ``shutil.rmtree``, except that when removal of an entry
+    fails, it clears the read-only attribute (the common cause on Windows
+    for git's read-only pack files under ``.git/objects/pack/``) and retries
+    once before giving up.
+
+    Args:
+        path: Directory to remove.
+        ignore_errors: If True, a failure that persists after the
+            read-only-clearing retry is swallowed (best-effort cleanup),
+            matching plain ``shutil.rmtree``'s own ``ignore_errors``
+            semantics. If False (default), a failure that persists raises
+            an ``OSError`` naming the path -- a cleanup removal that
+            silently fails must not be treated as if it succeeded.
+
+    Raises:
+        OSError: If ``ignore_errors`` is False and the directory still
+            exists after the removal attempt (including its read-only-clear
+            retries).
+    """
+    target = Path(path)
+
+    if not target.exists():
+        return
+
+    if sys.version_info >= (3, 12):
+        # onerror is deprecated since 3.12 in favor of onexc.
+        shutil.rmtree(target, onexc=_onexc)
+    else:
+        shutil.rmtree(target, onerror=_onerror)
+
+    if not ignore_errors and target.exists():
+        raise OSError(
+            f"Failed to remove directory even after clearing read-only "
+            f"attributes and retrying: {target}. This is not a transient "
+            "or read-only-attribute issue (those would have been healed by "
+            "the retry) -- check for files that are locked, in use, or "
+            "otherwise unremovable."
+        )

--- a/modules/tool-skills/amplifier_module_tool_skills/_rmtree.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/_rmtree.py
@@ -104,9 +104,6 @@ def rmtree_robust(path: Path | str, *, ignore_errors: bool = False) -> None:
     """
     target = Path(path)
 
-    if not target.exists():
-        return
-
     if sys.version_info >= (3, 12):
         # onerror is deprecated since 3.12 in favor of onexc.
         shutil.rmtree(target, onexc=_onexc)

--- a/modules/tool-skills/amplifier_module_tool_skills/sources.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/sources.py
@@ -247,7 +247,12 @@ async def _resolve_remote_source(source: str, cache_dir: Path) -> Path | None:
         # without metadata (atomic publish on rename).
         tmp_path = cache_path.with_name(cache_path.name + ".tmp")
         if tmp_path.exists():
-            rmtree_robust(tmp_path, ignore_errors=True)
+            # Loud (no ignore_errors): this staging dir is cloned into on the
+            # very next line, so a swallowed failure here surfaces later as
+            # git's misleading "destination path already exists" -- the exact
+            # symptom this healing exists to remove. A dir that survives even
+            # the read-only-clear retry is locked or in use; say so.
+            rmtree_robust(tmp_path)
 
         try:
             cmd = [

--- a/modules/tool-skills/amplifier_module_tool_skills/sources.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/sources.py
@@ -11,11 +11,12 @@ import hashlib
 import json
 import logging
 import os
-import shutil
 import signal
 import subprocess
 from datetime import datetime
 from pathlib import Path
+
+from ._rmtree import rmtree_robust
 
 logger = logging.getLogger(__name__)
 
@@ -236,13 +237,17 @@ async def _resolve_remote_source(source: str, cache_dir: Path) -> Path | None:
                 logger.warning(
                     f"Removing corrupt skills cache (no metadata): {cache_path}"
                 )
-                shutil.rmtree(cache_path)
+                # rmtree_robust (not shutil.rmtree): a corrupt cache dir is a git
+                # checkout whose pack files are read-only; on Windows plain rmtree
+                # raises PermissionError and the cache can never heal. Loud (no
+                # ignore_errors) so a genuinely stuck dir is reported, not hidden.
+                rmtree_robust(cache_path)
 
         # Clone into a temp path so the final cache_path is never visible
         # without metadata (atomic publish on rename).
         tmp_path = cache_path.with_name(cache_path.name + ".tmp")
         if tmp_path.exists():
-            shutil.rmtree(tmp_path, ignore_errors=True)
+            rmtree_robust(tmp_path, ignore_errors=True)
 
         try:
             cmd = [
@@ -274,7 +279,7 @@ async def _resolve_remote_source(source: str, cache_dir: Path) -> Path | None:
                 logger.error(f"Git clone failed: {result.stderr}")
                 # Clean up partial clone
                 if tmp_path.exists():
-                    shutil.rmtree(tmp_path, ignore_errors=True)
+                    rmtree_robust(tmp_path, ignore_errors=True)
                 return None
 
             # Write cache metadata to the temp dir (still not visible at cache_path)
@@ -305,7 +310,7 @@ async def _resolve_remote_source(source: str, cache_dir: Path) -> Path | None:
             # If cache_path now exists (cross-process race; another OS process
             # beat us), discard our temp clone and use theirs.
             if cache_path.exists():
-                shutil.rmtree(tmp_path, ignore_errors=True)
+                rmtree_robust(tmp_path, ignore_errors=True)
             else:
                 tmp_path.rename(cache_path)
 
@@ -320,12 +325,12 @@ async def _resolve_remote_source(source: str, cache_dir: Path) -> Path | None:
         except subprocess.TimeoutExpired:
             logger.error(f"Git clone timed out for: {url}")
             if tmp_path.exists():
-                shutil.rmtree(tmp_path, ignore_errors=True)
+                rmtree_robust(tmp_path, ignore_errors=True)
             return None
         except Exception as e:
             logger.error(f"Failed to clone skill source '{source}': {e}")
             if tmp_path.exists():
-                shutil.rmtree(tmp_path, ignore_errors=True)
+                rmtree_robust(tmp_path, ignore_errors=True)
             return None
 
 

--- a/modules/tool-skills/tests/test_sources.py
+++ b/modules/tool-skills/tests/test_sources.py
@@ -156,6 +156,79 @@ async def test_failed_clone_cleans_up_partial_directory(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_leftover_readonly_tmp_is_healed_before_reclone(tmp_path):
+    """A prior failed clone can leave a read-only ``.tmp`` staging dir behind.
+
+    Reproduces the Windows-permanent-failure bug: git marks pack files
+    (``.git/objects/pack/*.idx``) read-only. On Windows the read-only
+    attribute lives on the file and blocks deletion, so the old
+    ``shutil.rmtree(tmp_path, ignore_errors=True)`` at the pre-clone cleanup
+    silently no-ops, the ``.tmp`` survives, and every subsequent clone dies
+    with 'destination path already exists and is not an empty directory' --
+    forever. ``rmtree_robust`` must clear the read-only bit and remove it so
+    the re-clone proceeds.
+
+    On POSIX a read-only file is removable when its parent dir is writable, so
+    this test passes trivially on Linux/macOS. It genuinely fails pre-fix and
+    passes post-fix on Windows; keeping it cross-platform documents the
+    contract and guards it once a Windows CI leg exists.
+    """
+    import os
+    import stat
+
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    source = "git+https://github.com/example/my-skills@main"
+
+    expected_cache = _compute_cache_path(source, cache_dir)
+    # Pre-seed the orphaned .tmp a prior failed clone would have left behind,
+    # with a read-only pack file inside it (the exact thing that jams Windows).
+    tmp_leftover = expected_cache.with_name(expected_cache.name + ".tmp")
+    pack_dir = tmp_leftover / ".git" / "objects" / "pack"
+    pack_dir.mkdir(parents=True)
+    stuck = pack_dir / "pack-abc.idx"
+    stuck.write_text("readonly pack index", encoding="utf-8")
+    os.chmod(stuck, stat.S_IREAD)  # 0o444 — read-only, as git leaves it
+
+    def fake_clone(cmd, **kwargs):
+        """A now-successful clone into the (freshly cleared) tmp dir."""
+        if "clone" in cmd:
+            dest = Path(cmd[-1])
+            # git refuses a non-empty destination; if the leftover wasn't
+            # cleared this returns 128 and the test's assertions below fail.
+            if dest.exists() and any(dest.iterdir()):
+                return subprocess.CompletedProcess(
+                    cmd,
+                    128,
+                    "",
+                    f"fatal: destination path '{dest}' already exists and is "
+                    "not an empty directory.",
+                )
+            dest.mkdir(parents=True, exist_ok=True)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    mock_sha_proc = AsyncMock()
+    mock_sha_proc.returncode = 0
+    mock_sha_proc.communicate = AsyncMock(return_value=(b"feedface00000000\n", b""))
+
+    try:
+        with patch(_CLONE_SEAM, side_effect=fake_clone):
+            with patch("asyncio.create_subprocess_exec", return_value=mock_sha_proc):
+                result = await _resolve_remote_source(source, cache_dir)
+    finally:
+        # Never leave a read-only file that would jam pytest's own tmp cleanup.
+        if stuck.exists():
+            os.chmod(stuck, stat.S_IWRITE | stat.S_IREAD)
+
+    assert not tmp_leftover.exists(), (
+        "The orphaned read-only .tmp staging dir must be cleared before the "
+        "re-clone; if it survives, git aborts on a non-empty destination and "
+        "the source can never resolve again."
+    )
+    assert result is not None, "Expected a resolved path after the leftover was healed"
+
+
+@pytest.mark.asyncio
 async def test_valid_cache_with_metadata_returned_without_reclone(tmp_path):
     """A cache directory with .amplifier_cache_meta.json is returned directly.
 


### PR DESCRIPTION
## The bug

A failed skill-source git clone leaves a `<cache>.tmp` staging dir behind. Git marks pack files (`.git/objects/pack/*.idx`) **read-only**. On Windows the read-only attribute lives on the file and blocks deletion, so the pre-clone cleanup —

```python
if tmp_path.exists():
    shutil.rmtree(tmp_path, ignore_errors=True)
```

— hits `PermissionError`, `ignore_errors=True` **silently swallows it**, and the `.tmp` survives. Every subsequent run then dies with git's own error:

```
fatal: destination path '...-<hash>.tmp' already exists and is not an empty directory.
```

…forever, until the directory is hand-deleted. Reported from a real fresh Windows install of amplifier (the `amplifier-bundle-resolve` skill source, but it applies to any skill source whose clone fails once).

**POSIX is unaffected** — removing a read-only file there only needs a writable parent — so this is Windows-only and does not touch the working Linux/macOS population.

## The fix

`amplifier-foundation` already fixed this exact class in `sources/git.py` via `rmtree_robust` (`sources/_rmtree.py`), but `tool-skills` hand-rolls its own clone in `sources.py` and never received it.

- **Vendored** `_rmtree.py` into the module. Foundation is only an *optional* dependency of tool-skills, so importing it at runtime isn't reliable — a small self-contained helper is cheaper than a hard dependency. Kept in sync with foundation's copy, noted in the module docstring.
- **All six `shutil.rmtree` sites** in `sources.py` now use `rmtree_robust`, which clears the read-only bit and retries. Best-effort cleanup sites keep `ignore_errors=True`; the corrupt-cache removal stays loud (raises if genuinely stuck).
- `+12/-7` in `sources.py`, dead `shutil` import dropped.

## Evidence — native Windows 11, Python 3.14.3

New test `test_leftover_readonly_tmp_is_healed_before_reclone` seeds a read-only `.idx` inside an orphaned `.tmp`, then drives the resolve path. Run against both trees on the box:

```
=== baseline (original shutil.rmtree) ===
FAILED tests/test_sources.py::test_leftover_readonly_tmp_is_healed_before_reclone
  AssertionError: The orphaned read-only .tmp staging dir must be cleared before the re-clone
  ERROR ...sources.py:274 Git clone failed: fatal: destination path
    '...my-skills-<hash>.tmp' already exists and is not an empty directory.
1 failed, 4 deselected

=== fixed (rmtree_robust) ===
1 passed, 4 deselected
```

The baseline failure reproduces the reported symptom verbatim; the fix clears it.

## Honesty note on the test

The new test is **vacuous on POSIX** — a read-only file is removable there, so it passes with or without the fix on Linux. It has teeth **only on Windows**, which is exactly why the baseline/fixed split above was run on the box rather than trusted from a green Linux run. The test docstring says this plainly so a future reader doesn't mistake a green Linux run for proof.

**Linux regression:** `5 passed` with the change (4 pre-existing + the new one).

## Limits

- One Windows machine, one Python version (3.14.3). No Windows CI leg on this repo yet — once there is one, this test becomes a live guard instead of a documented-intent one.