### PR TITLE
fix: load Windows-authored SKILL.md files + safe shell-exec on Windows

### DIFF
--- a/modules/tool-skills/amplifier_module_tool_skills/discovery.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/discovery.py
@@ -84,7 +84,13 @@ def parse_skill_frontmatter(skill_path: Path) -> dict[str, Any] | None:
         Dictionary of frontmatter fields, or None if invalid
     """
     try:
-        content = skill_path.read_text(encoding="utf-8")
+        # utf-8-sig (not utf-8): a SKILL.md authored on Windows (Notepad,
+        # PowerShell Out-File, many editors) is UTF-8 WITH a BOM. Reading it as
+        # plain utf-8 leaves the BOM (\ufeff) as the file's first char, so
+        # content.startswith("---") is False and the skill is silently dropped
+        # ("missing YAML frontmatter"). utf-8-sig strips a leading BOM if present
+        # and is identical to utf-8 for files without one.
+        content = skill_path.read_text(encoding="utf-8-sig")
     except (OSError, UnicodeDecodeError) as e:
         logger.warning(f"Failed to read {skill_path}: {e}")
         return None
@@ -120,7 +126,9 @@ def extract_skill_body(skill_path: Path) -> str | None:
         Markdown content after frontmatter, or None if invalid
     """
     try:
-        content = skill_path.read_text(encoding="utf-8")
+        # utf-8-sig: strip a Windows-authored BOM so the frontmatter delimiter is
+        # detected here exactly as in parse_skill_frontmatter (see note there).
+        content = skill_path.read_text(encoding="utf-8-sig")
     except (OSError, UnicodeDecodeError) as e:
         logger.warning(f"Failed to read {skill_path}: {e}")
         return None

--- a/modules/tool-skills/amplifier_module_tool_skills/preprocessing.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/preprocessing.py
@@ -29,8 +29,10 @@ MAX_SHELL_OUTPUT_BYTES = 1_048_576  # 1 MB
 # The POSIX set below is joined by a Windows set: create_subprocess_shell spawns via
 # cmd.exe on Windows, and omitting SystemRoot/ComSpec/PATHEXT/etc. from a custom env=
 # makes cmd.exe (and many programs it launches) fail to start entirely -- so on Windows
-# these are essential, not secrets. Matching is case-insensitive (Windows env-var names
-# are case-insensitive; os.environ preserves whatever case was set).
+# these are essential, not secrets. Matching is case-insensitive because Windows env-var
+# names are case-insensitive, and CPython's os.environ upper-cases keys on Windows while
+# preserving case on POSIX -- so neither the stored case nor the literal above is a
+# reliable key to match on.
 _SAFE_ENV_KEYS_POSIX: frozenset[str] = frozenset(
     {"PATH", "HOME", "TMPDIR", "LANG", "TERM", "USER", "SHELL", "LC_ALL"}
 )

--- a/modules/tool-skills/amplifier_module_tool_skills/preprocessing.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/preprocessing.py
@@ -26,21 +26,54 @@ MAX_SHELL_OUTPUT_BYTES = 1_048_576  # 1 MB
 
 # Only these environment variables are passed to subprocesses spawned by shell commands.
 # This prevents API keys and secrets from leaking into subprocess environments.
-_SAFE_ENV_KEYS: frozenset[str] = frozenset(
+# The POSIX set below is joined by a Windows set: create_subprocess_shell spawns via
+# cmd.exe on Windows, and omitting SystemRoot/ComSpec/PATHEXT/etc. from a custom env=
+# makes cmd.exe (and many programs it launches) fail to start entirely -- so on Windows
+# these are essential, not secrets. Matching is case-insensitive (Windows env-var names
+# are case-insensitive; os.environ preserves whatever case was set).
+_SAFE_ENV_KEYS_POSIX: frozenset[str] = frozenset(
     {"PATH", "HOME", "TMPDIR", "LANG", "TERM", "USER", "SHELL", "LC_ALL"}
 )
+_SAFE_ENV_KEYS_WINDOWS: frozenset[str] = frozenset(
+    {
+        "PATH",
+        "PATHEXT",
+        "SYSTEMROOT",
+        "SYSTEMDRIVE",
+        "COMSPEC",
+        "WINDIR",
+        "USERPROFILE",
+        "HOMEDRIVE",
+        "HOMEPATH",
+        "TEMP",
+        "TMP",
+        "APPDATA",
+        "LOCALAPPDATA",
+        "PROGRAMDATA",
+        "PROGRAMFILES",
+        "PROGRAMFILES(X86)",
+        "NUMBER_OF_PROCESSORS",
+        "PROCESSOR_ARCHITECTURE",
+    }
+)
+# Retained for backward-compatibility / tests that import the original name.
+_SAFE_ENV_KEYS: frozenset[str] = _SAFE_ENV_KEYS_POSIX
 
 
 def _build_safe_env() -> dict[str, str]:
     """Build a minimal environment dict for subprocess execution.
 
-    Returns only the keys in _SAFE_ENV_KEYS that are present in os.environ,
-    preventing API keys and other secrets from leaking into subprocesses.
+    Returns only the safe keys present in os.environ, preventing API keys and
+    other secrets from leaking into subprocesses. On Windows the allowlist is the
+    Windows-essential set (matched case-insensitively); on POSIX it is the POSIX
+    set.
 
     Returns:
         Dict containing only the safe subset of the current environment.
     """
-    return {k: v for k, v in os.environ.items() if k in _SAFE_ENV_KEYS}
+    allowed = _SAFE_ENV_KEYS_WINDOWS if os.name == "nt" else _SAFE_ENV_KEYS_POSIX
+    allowed_upper = {k.upper() for k in allowed}
+    return {k: v for k, v in os.environ.items() if k.upper() in allowed_upper}
 
 
 def _substitute_system_variables(body: str, skill_dir: Path) -> str:
@@ -147,9 +180,17 @@ async def _run_shell_command(command: str, cwd: Path) -> str:
                 proc.communicate(), timeout=30.0
             )
         except asyncio.TimeoutError:
+            # os.killpg/os.getpgid/SIGKILL are POSIX-only -- they do not exist on
+            # Windows (AttributeError), and start_new_session (used above) is a
+            # silent no-op there, so there is no process group to signal anyway.
+            # On Windows, terminate the child directly; on POSIX, kill the whole
+            # process group so shell-spawned grandchildren die too.
             try:
-                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-            except (ProcessLookupError, PermissionError):
+                if os.name == "nt":
+                    proc.kill()
+                else:
+                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except (ProcessLookupError, PermissionError, AttributeError):
                 proc.kill()
             await proc.communicate()
             logger.warning(f"Shell command timed out: {command!r}")

--- a/modules/tool-skills/tests/test_windows_skill_loading.py
+++ b/modules/tool-skills/tests/test_windows_skill_loading.py
@@ -8,7 +8,9 @@ Three bugs were fixed:
      behaviour is platform-independent, so the old code fails this test here too.
   2. The shell-command timeout handler called os.killpg/os.getpgid/SIGKILL,
      which do not exist on Windows -> AttributeError + orphaned child. Verified
-     by asserting the handler now guards on os.name and swallows AttributeError.
+     BEHAVIOURALLY: the timeout branch is driven with os.name forced to "nt" and
+     the kill calls are observed, so the test fails if the guard is removed,
+     misplaced, or refactored into a no-op.
   3. _build_safe_env()'s allowlist was POSIX-only vocabulary, so cmd.exe (which
      create_subprocess_shell uses on Windows) lost SystemRoot/ComSpec/PATHEXT
      and failed to spawn. Verified by asserting the Windows allowlist carries
@@ -16,6 +18,7 @@ Three bugs were fixed:
 """
 
 import os
+import signal
 from pathlib import Path
 from unittest.mock import patch
 
@@ -72,41 +75,134 @@ class TestWindowsSafeEnv:
 
         upper = {k.upper() for k in _SAFE_ENV_KEYS_WINDOWS}
         for essential in ("SYSTEMROOT", "COMSPEC", "PATHEXT", "PATH", "TEMP"):
-            assert essential in upper, f"{essential} missing from Windows safe-env allowlist"
+            assert essential in upper, (
+                f"{essential} missing from Windows safe-env allowlist"
+            )
 
     def test_build_safe_env_forwards_systemroot_on_windows(self):
         from amplifier_module_tool_skills.preprocessing import _build_safe_env
 
         fake_env = {
-            "SystemRoot": r"C:\Windows",   # note the real-world mixed case
+            "SystemRoot": r"C:\Windows",  # note the real-world mixed case
             "ComSpec": r"C:\Windows\System32\cmd.exe",
             "PATH": r"C:\Windows",
             "SECRET_API_KEY": "sk-must-not-leak",
         }
-        with patch.object(os, "name", "nt"), patch.dict(os.environ, fake_env, clear=True):
+        with (
+            patch.object(os, "name", "nt"),
+            patch.dict(os.environ, fake_env, clear=True),
+        ):
             env = _build_safe_env()
+        # Look the keys up case-INSENSITIVELY. On a real Windows interpreter,
+        # os.environ upper-cases every key on __setitem__ (see CPython os.py:
+        # "Where Env Var Names Must Be UPPERCASE"), so patch.dict stores
+        # "SystemRoot" as "SYSTEMROOT" there but leaves it mixed-case on POSIX.
+        # Asserting on the literal mixed-case key would pass on Linux/macOS and
+        # fail on Windows -- the one platform this test exists to protect.
+        got = {k.upper(): v for k, v in env.items()}
         # cmd.exe essentials forwarded despite mixed case; secrets dropped.
-        assert env.get("SystemRoot") == r"C:\Windows"
-        assert env.get("ComSpec") == r"C:\Windows\System32\cmd.exe"
-        assert "SECRET_API_KEY" not in env
+        assert got.get("SYSTEMROOT") == r"C:\Windows"
+        assert got.get("COMSPEC") == r"C:\Windows\System32\cmd.exe"
+        assert "SECRET_API_KEY" not in got
 
     def test_build_safe_env_posix_unchanged(self):
         from amplifier_module_tool_skills.preprocessing import _build_safe_env
 
         fake_env = {"PATH": "/usr/bin", "HOME": "/home/x", "SECRET": "nope"}
-        with patch.object(os, "name", "posix"), patch.dict(os.environ, fake_env, clear=True):
+        with (
+            patch.object(os, "name", "posix"),
+            patch.dict(os.environ, fake_env, clear=True),
+        ):
             env = _build_safe_env()
         assert env == {"PATH": "/usr/bin", "HOME": "/home/x"}
 
 
+class _FakeProc:
+    """Stand-in for the asyncio subprocess whose communicate() times out."""
+
+    def __init__(self) -> None:
+        self.pid = 424242
+        self.returncode = -9
+        self.kill_calls = 0
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+
+    async def communicate(self):
+        return (b"", b"")
+
+
+def _drive_timeout(*, os_name: str, killpg_raises: type[BaseException] | None = None):
+    """Drive _run_shell_command through its timeout branch and report what it killed.
+
+    Returns (result_string, fake_proc, killpg_calls). No real process is spawned:
+    create_subprocess_shell is stubbed and the 30s wait_for is forced to time out,
+    so this exercises the real kill path in milliseconds on any platform.
+    """
+    import asyncio
+
+    import amplifier_module_tool_skills.preprocessing as pp
+
+    proc = _FakeProc()
+    killpg_calls: list[tuple] = []
+
+    def fake_killpg(pgid, sig):
+        killpg_calls.append((pgid, sig))
+        if killpg_raises is not None:
+            raise killpg_raises()
+
+    async def fake_create(*_args, **_kwargs):
+        return proc
+
+    real_wait_for = asyncio.wait_for
+
+    async def fake_wait_for(awaitable, timeout=None):
+        # Only hijack _run_shell_command's own 30s guard; let asyncio internals
+        # use the real wait_for so patching stays confined to the code under test.
+        if timeout == 30.0:
+            awaitable.close()  # we never await it; avoids "never awaited" warning
+            raise asyncio.TimeoutError
+        return await real_wait_for(awaitable, timeout)
+
+    with (
+        patch.object(os, "name", os_name),
+        patch.object(os, "killpg", fake_killpg, create=True),
+        patch.object(os, "getpgid", lambda pid: pid, create=True),
+        patch.object(asyncio, "create_subprocess_shell", fake_create),
+        patch.object(asyncio, "wait_for", fake_wait_for),
+    ):
+        result = asyncio.run(pp._run_shell_command("sleep 999", Path(".")))
+
+    return result, proc, killpg_calls
+
+
 class TestTimeoutKillGuarded:
-    """Bug 2: the timeout kill path must not call POSIX-only os.killpg on Windows."""
+    """Bug 2: the timeout kill path must not call POSIX-only os.killpg on Windows.
 
-    def test_source_guards_killpg_for_windows(self):
-        import amplifier_module_tool_skills.preprocessing as pp
+    These assert on BEHAVIOUR (what the kill path actually calls), not on the
+    source text. A source grep passes even if the guard lands in the wrong
+    function, and breaks on a harmless refactor -- it tests the implementation
+    instead of the contract.
+    """
 
-        src = Path(pp.__file__).read_text(encoding="utf-8")
-        # The kill path is guarded on os.name and catches AttributeError so a
-        # Windows AttributeError from os.killpg can never orphan the child.
-        assert 'os.name == "nt"' in src
-        assert "AttributeError" in src
+    def test_windows_timeout_kills_child_directly(self):
+        result, proc, killpg_calls = _drive_timeout(os_name="nt")
+        assert killpg_calls == [], "POSIX-only os.killpg was called on Windows"
+        assert proc.kill_calls >= 1, "timed-out child was never killed on Windows"
+        assert "timed out" in result
+
+    def test_posix_timeout_still_kills_process_group(self):
+        # No regression: POSIX keeps group-killing so shell-spawned grandchildren die.
+        result, proc, killpg_calls = _drive_timeout(os_name="posix")
+        assert len(killpg_calls) == 1, "POSIX no longer kills the process group"
+        assert killpg_calls[0][1] == signal.SIGKILL
+        assert proc.kill_calls == 0
+        assert "timed out" in result
+
+    def test_killpg_attribute_error_falls_back_to_proc_kill(self):
+        # Simulates a real Windows interpreter, where os.killpg does not exist at
+        # all: the AttributeError must be swallowed and the child killed anyway,
+        # rather than escaping and orphaning it.
+        result, proc, _ = _drive_timeout(os_name="posix", killpg_raises=AttributeError)
+        assert proc.kill_calls >= 1, "AttributeError escaped and orphaned the child"
+        assert "timed out" in result

--- a/modules/tool-skills/tests/test_windows_skill_loading.py
+++ b/modules/tool-skills/tests/test_windows_skill_loading.py
@@ -1,0 +1,112 @@
+"""Windows-compatibility tests for the tool-skills load/discovery path.
+
+Three bugs were fixed:
+  1. SKILL.md was read as "utf-8" (not "utf-8-sig"). A Windows-authored file
+     (Notepad, PowerShell Out-File, many editors) is UTF-8 WITH a BOM, so the
+     retained \ufeff made content.startswith("---") False and the skill was
+     silently dropped ("missing YAML frontmatter"). TEETH ON LINUX -- the BOM
+     behaviour is platform-independent, so the old code fails this test here too.
+  2. The shell-command timeout handler called os.killpg/os.getpgid/SIGKILL,
+     which do not exist on Windows -> AttributeError + orphaned child. Verified
+     by asserting the handler now guards on os.name and swallows AttributeError.
+  3. _build_safe_env()'s allowlist was POSIX-only vocabulary, so cmd.exe (which
+     create_subprocess_shell uses on Windows) lost SystemRoot/ComSpec/PATHEXT
+     and failed to spawn. Verified by asserting the Windows allowlist carries
+     those keys and matches case-insensitively.
+"""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from amplifier_module_tool_skills.discovery import extract_skill_body
+from amplifier_module_tool_skills.discovery import parse_skill_frontmatter
+
+# NB: the _SAFE_ENV_KEYS_WINDOWS / _build_safe_env imports are done lazily inside
+# the env tests below, NOT at module scope. Otherwise, running this file against
+# the UN-fixed code (where those symbols don't exist) would fail at COLLECTION and
+# mask the BOM teeth -- the BOM tests only need discovery, which exists on baseline.
+
+_SKILL = "---\nname: bom-skill\ndescription: A skill\nversion: 1.0.0\n---\nBody here\n"
+
+
+class TestBomFrontmatter:
+    """Bug 1: a UTF-8 BOM must not hide the frontmatter. Teeth on Linux."""
+
+    def test_frontmatter_parsed_from_bom_file(self, tmp_path: Path):
+        f = tmp_path / "SKILL.md"
+        # Write UTF-8 WITH BOM, exactly as a Windows editor would.
+        f.write_bytes(b"\xef\xbb\xbf" + _SKILL.encode("utf-8"))
+        fm = parse_skill_frontmatter(f)
+        assert fm is not None, "BOM'd SKILL.md was dropped as if it had no frontmatter"
+        assert fm["name"] == "bom-skill"
+
+    def test_body_extracted_from_bom_file(self, tmp_path: Path):
+        f = tmp_path / "SKILL.md"
+        f.write_bytes(b"\xef\xbb\xbf" + _SKILL.encode("utf-8"))
+        body = extract_skill_body(f)
+        assert body == "Body here"
+
+    def test_plain_utf8_still_parses(self, tmp_path: Path):
+        # No regression: a normal (no-BOM) file still works.
+        f = tmp_path / "SKILL.md"
+        f.write_text(_SKILL, encoding="utf-8")
+        fm = parse_skill_frontmatter(f)
+        assert fm is not None and fm["name"] == "bom-skill"
+
+    def test_crlf_bom_file_parses(self, tmp_path: Path):
+        # The nastiest real Windows file: BOM + CRLF line endings.
+        f = tmp_path / "SKILL.md"
+        f.write_bytes(b"\xef\xbb\xbf" + _SKILL.replace("\n", "\r\n").encode("utf-8"))
+        fm = parse_skill_frontmatter(f)
+        assert fm is not None and fm["name"] == "bom-skill"
+
+
+class TestWindowsSafeEnv:
+    """Bug 3: the shell-exec env allowlist must be Windows-viable."""
+
+    def test_windows_allowlist_has_cmd_essentials(self):
+        # Lazy import (see module docstring) so this file collects against the
+        # un-fixed code where these symbols don't yet exist.
+        from amplifier_module_tool_skills.preprocessing import _SAFE_ENV_KEYS_WINDOWS
+
+        upper = {k.upper() for k in _SAFE_ENV_KEYS_WINDOWS}
+        for essential in ("SYSTEMROOT", "COMSPEC", "PATHEXT", "PATH", "TEMP"):
+            assert essential in upper, f"{essential} missing from Windows safe-env allowlist"
+
+    def test_build_safe_env_forwards_systemroot_on_windows(self):
+        from amplifier_module_tool_skills.preprocessing import _build_safe_env
+
+        fake_env = {
+            "SystemRoot": r"C:\Windows",   # note the real-world mixed case
+            "ComSpec": r"C:\Windows\System32\cmd.exe",
+            "PATH": r"C:\Windows",
+            "SECRET_API_KEY": "sk-must-not-leak",
+        }
+        with patch.object(os, "name", "nt"), patch.dict(os.environ, fake_env, clear=True):
+            env = _build_safe_env()
+        # cmd.exe essentials forwarded despite mixed case; secrets dropped.
+        assert env.get("SystemRoot") == r"C:\Windows"
+        assert env.get("ComSpec") == r"C:\Windows\System32\cmd.exe"
+        assert "SECRET_API_KEY" not in env
+
+    def test_build_safe_env_posix_unchanged(self):
+        from amplifier_module_tool_skills.preprocessing import _build_safe_env
+
+        fake_env = {"PATH": "/usr/bin", "HOME": "/home/x", "SECRET": "nope"}
+        with patch.object(os, "name", "posix"), patch.dict(os.environ, fake_env, clear=True):
+            env = _build_safe_env()
+        assert env == {"PATH": "/usr/bin", "HOME": "/home/x"}
+
+
+class TestTimeoutKillGuarded:
+    """Bug 2: the timeout kill path must not call POSIX-only os.killpg on Windows."""
+
+    def test_source_guards_killpg_for_windows(self):
+        import amplifier_module_tool_skills.preprocessing as pp
+
+        src = Path(pp.__file__).read_text(encoding="utf-8")
+        # The kill path is guarded on os.name and catches AttributeError so a
+        # Windows AttributeError from os.killpg can never orphan the child.
+        assert 'os.name == "nt"' in src
+        assert "AttributeError" in src


### PR DESCRIPTION
## Summary

Three **Windows-only** defects in the tool-skills **load/discovery** path (the git-clone path was fixed separately in #58). Full hazard checklist audited — encoding at all other read sites, `expanduser`, `os.walk`, and name derivation were already clean.

## The bugs

**1. A Windows-authored `SKILL.md` was silently dropped.** It was read as `encoding="utf-8"` (not `"utf-8-sig"`). Files authored on Windows (Notepad, PowerShell `Out-File`, many editors) are UTF-8 **with a BOM**, so the retained `\ufeff` made `content.startswith("---")` False and the skill vanished as *"missing YAML frontmatter"* — the **exact symptom seen on a real Windows box** (and reported from codex on the same machine). Now reads `utf-8-sig` at both read sites (strips a leading BOM if present; identical to utf-8 otherwise).

**2. The shell-command timeout handler crashed and orphaned the child on Windows.** It called `os.killpg`/`os.getpgid`/`SIGKILL` — all POSIX-only → `AttributeError` that escaped the intended handler, masked the timeout message, and left the timed-out child running. Now guards on `os.name` (`proc.kill()` on Windows, `killpg` on POSIX) and catches `AttributeError`.

**3. `_build_safe_env()`'s allowlist broke `cmd.exe`.** It was POSIX-only vocabulary. `create_subprocess_shell` spawns via `cmd.exe` on Windows, and omitting `SystemRoot`/`ComSpec`/`PATHEXT` from a custom `env=` makes `cmd.exe` fail to start at all. Now uses a Windows allowlist matched **case-insensitively** on Windows; the POSIX set is byte-unchanged on POSIX.

## Evidence — teeth both ways

**Linux:** existing discovery + preprocessing suites + 8 new tests = **44 passed** (no regression). The 3 BOM tests **FAIL against the un-fixed code** (parse returns `None`) and pass with the fix — the BOM behaviour is platform-independent, so they have real teeth on Linux.

**Windows** (native, Python 3.14.3): real `discover_skills()` on a **BOM+CRLF** `SKILL.md`:

```
BASELINE:  bom_frontmatter_parsed=None   discovered=[]
           safe_env SystemRoot=False ComSpec=False   -> all_ok=False
FIXED:     frontmatter=bom-skill          discovered=['bom-skill']
           safe_env SystemRoot=True  ComSpec=True     -> all_ok=True
```

Baseline reproduces the reported symptom (skill silently dropped); the fix discovers it.

## Limits

One Windows machine, one Python (3.14.3). No Windows CI leg on this repo yet — the BOM tests run everywhere (real teeth), but the env/timeout guards were exercised on the box, not in CI.