### PR TITLE
fix: make the remote-skills cache honour AMPLIFIER_HOME

### DIFF
--- a/modules/tool-skills/amplifier_module_tool_skills/sources.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/sources.py
@@ -20,8 +20,35 @@ from ._rmtree import rmtree_robust
 
 logger = logging.getLogger(__name__)
 
-# Default cache directory for remote skills
-DEFAULT_SKILLS_CACHE_DIR = Path("~/.amplifier/cache/skills").expanduser()
+
+def default_skills_cache_dir() -> Path:
+    """Return the default cache directory for remote skills.
+
+    Honours ``AMPLIFIER_HOME``, matching ``amplifier_foundation.paths``'s
+    ``get_amplifier_home()``, which is the ecosystem's single source of truth
+    for where an application's Amplifier data lives::
+
+        env_home = os.environ.get("AMPLIFIER_HOME")
+        if env_home:
+            return Path(env_home).expanduser().resolve()
+        return (Path.home() / ".amplifier").resolve()
+
+    Previously this was a module-level constant hardcoded to
+    ``~/.amplifier/cache/skills``.  That made this module the one part of the
+    skills tool that ignored the variable every other cache path in the stack
+    respects, so an application that relocated its Amplifier home still had its
+    remote skill clones written into ``~/.amplifier`` -- shared with, and
+    indistinguishable from, any other Amplifier app on the machine.
+
+    Resolved per call rather than at import so that a caller which sets
+    ``AMPLIFIER_HOME`` during startup is not silently defeated by import order.
+    """
+    env_home = os.environ.get("AMPLIFIER_HOME")
+    base = (
+        Path(env_home).expanduser() if env_home else Path("~/.amplifier").expanduser()
+    )
+    return base / "cache" / "skills"
+
 
 # Per-cache-path asyncio locks — defence-in-depth against concurrent clones.
 # The primary guard is deduplication in resolve_skill_sources; the lock
@@ -104,7 +131,7 @@ async def resolve_skill_source(
     Returns:
         Path to local directory containing skills, or None if resolution fails.
     """
-    cache_dir = cache_dir or DEFAULT_SKILLS_CACHE_DIR
+    cache_dir = cache_dir or default_skills_cache_dir()
 
     # Local path - just expand and return
     if not is_remote_source(source):
@@ -360,7 +387,7 @@ async def resolve_skill_sources(
     Returns:
         List of resolved local paths (in priority order).
     """
-    cache_dir = cache_dir or DEFAULT_SKILLS_CACHE_DIR
+    cache_dir = cache_dir or default_skills_cache_dir()
 
     # Separate local and remote sources while preserving order info
     local_sources: list[tuple[int, str]] = []


### PR DESCRIPTION
## Summary

`DEFAULT_SKILLS_CACHE_DIR` was hardcoded:

```python
# modules/tool-skills/amplifier_module_tool_skills/sources.py:24
DEFAULT_SKILLS_CACHE_DIR = Path("~/.amplifier/cache/skills").expanduser()
```

This is the one cache path in the skills tool that ignores `AMPLIFIER_HOME`, the variable the rest of the stack respects via `amplifier_foundation.paths.get_amplifier_home()`. An application that relocates its Amplifier home still had remote skill clones written into `~/.amplifier` — shared with, and indistinguishable from, every other Amplifier app on the machine.

## How it was found

While decoupling `amplifier-agent` from `amplifier-app-cli`'s `~/.amplifier` directory. After binding `AMPLIFIER_HOME` to the app's own tree, a clean-container run still produced:

```
/root/.amplifier/cache/skills/amplifier-foundation-c909465861f9d6ce
```

Everything else moved. This did not.

Not reachable via config either — `__init__.py:177` calls `resolve_skill_sources(sources)` with no `cache_dir`, so the default always applies and no bundle-level setting can override it.

## The change

Replaced the module-level constant with `default_skills_cache_dir()`, resolved **per call** rather than at import, so a caller that sets `AMPLIFIER_HOME` during startup is not silently defeated by import order.

Behaviour is unchanged when `AMPLIFIER_HOME` is unset: still `~/.amplifier/cache/skills`.

## API note

`DEFAULT_SKILLS_CACHE_DIR` is removed in favour of the function. It is not re-exported from the package `__init__`, and the only two references were the internal call sites updated here — but flagging it explicitly in case anything out-of-tree imports it.

## Verification

Verified in a clean Incus container as part of the amplifier-agent decoupling work: with the fix applied and `AMPLIFIER_HOME` bound to the app's own tree, a real agent turn no longer creates `~/.amplifier`.

## Checks

`ruff check` reports 5 errors on this file **both before and after** this change — pre-existing, and the repo pins no ruff config.