### PR TITLE
chore(context): remove stale/duplicated always-on context (validated deletion pass)

### DIFF
--- a/context/skills-instructions.md
+++ b/context/skills-instructions.md
@@ -12,41 +12,13 @@ Skills are domain knowledge packages following the [Agent Skills specification](
 
 ## Skills Visibility
 
-When skills are available, you'll see them automatically in your context before each request:
-
-```
-<available_skills>
-Available skills (use load_skill tool):
-
-- **python-testing**: Best practices for Python testing with pytest
-- **git-workflow**: Git branching and commit message standards
-- **api-design**: RESTful API design patterns and conventions
-</available_skills>
-```
-
-You don't need to call `load_skill(list=true)` first - skills are made visible automatically through the visibility hook.
+The available-skills catalog is injected into your context automatically before each
+request. You don't need to call `load_skill(list=true)` first.
 
 ## Available Tool: load_skill
 
-**Operations:**
-
-- `load_skill(list=true)` - List all available skills
-- `load_skill(search="pattern")` - Filter by keyword
-- `load_skill(info="skill-name")` - Get metadata only
-- `load_skill(skill_name="skill-name")` - Load full content
-
-**Usage Examples:**
-
-```
-# List available skills (if not already visible)
-load_skill(list=true)
-
-# Search for specific skills
-load_skill(search="python")
-
-# Load a skill
-load_skill(skill_name="example-skill")
-```
+Operations and usage are in the `load_skill` tool description. The common case is
+`load_skill(skill_name="…")` to load a skill's full content.
 
 ## Enhanced Skills (Fork Execution)
 
@@ -71,58 +43,13 @@ Three power skills ship with the curated collection. These are user-invoked via 
 
 These skills have `disable-model-invocation: true`, meaning they won't appear in the automatic skills visibility list. They are invoked by the user explicitly — via slash command (`/session-debug`, `/code-review`, `/mass-change`) or by calling `load_skill(skill_name="session-debug")` directly. When the user types one of these slash commands, load and execute the corresponding skill.
 
-## Skills Discovery
+## Discovering, Configuring, and Authoring Skills
 
-Skills are discovered from these locations by default:
-1. `.amplifier/skills/` (workspace)
-2. `~/.amplifier/skills/` (user home)
-3. `AMPLIFIER_SKILLS_DIR` environment variable
-
-When multiple directories contain the same skill name, the first match wins (priority order matches the list order).
-
-## Configuration
-
-The skills tool supports custom directory configuration:
-
-```yaml
-tools:
-  - module: tool-skills
-    config:
-      skills_dirs:
-        - /custom/path/to/skills
-        - /another/path
-      visibility:
-        enabled: true              # Show skills automatically (default: true)
-        max_skills_visible: 50     # Limit for large collections (default: 50)
-```
-
-## Configuring Skills in Bundles
-
-If your bundle ships its own skills or depends on community skills, configure them through the `tools:` section as module config for `tool-skills`:
-
-```yaml
-tools:
-  - module: tool-skills
-    source: git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=modules/tool-skills
-    config:
-      skills:
-        - "git+https://github.com/my-org/my-skills-repo@main#subdirectory=skills"
-        - "@mybundle:skills"
-```
-
-The `config.skills` list accepts three source types:
-
-| Source type | Example | When to use |
-|-------------|---------|-------------|
-| Git URL | `git+https://github.com/org/repo@main#subdirectory=skills` | Remote community or shared skill repos |
-| Bundle reference | `@mybundle:skills` | Skills shipped inside your own bundle |
-| Local path | `/absolute/path/to/skills` | Development and testing |
-
-Git URLs support an optional `#subdirectory=` fragment to point at a subfolder within the repo.
-
-Bundle references (`@mybundle:skills`) resolve through the session's mention resolver, which becomes available shortly after modules mount — so skills from `@`-sources register at the first request of the session rather than at mount time. If a source cannot be resolved, a warning naming it appears in the session log.
-
-> **Warning:** Do NOT use a top-level `skills:` key in your bundle frontmatter. The foundation layer does not process it -- skill sources placed there will be **silently ignored**. Always use the `tools:` config pattern shown above.
+Skill discovery paths and precedence, `tool-skills` configuration (`skills_dirs`,
+`visibility`), and how to ship skills from a bundle (`config.skills` source types, the
+`#subdirectory=` fragment, the silently-ignored top-level `skills:` key) are bundle-author
+concerns. Load `load_skill(skill_name="skills-assist")` or read its `authoring-guide.md`
+companion when you need them.
 
 ## Skills Expert
 

--- a/modules/tool-skills/amplifier_module_tool_skills/__init__.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/__init__.py
@@ -485,7 +485,6 @@ Operations:
   companion files referenced in the skill.
 
 Usage Guidelines:
-- Start tasks by listing or searching skills to discover relevant domain knowledge
 - Use info operation to check skills before loading to conserve context
 - Skills may reference companion files - use the returned skill_directory path with read_file tool
   Example: If skill returns skill_directory="/path/to/skill", you can read companion files with


### PR DESCRIPTION
## What lands here

From the 1e2 context-hygiene treatment MANIFEST:

- **C4** (correctness): `modules/tool-skills/amplifier_module_tool_skills/__init__.py`'s `SkillsTool` description told the model to "Start tasks by listing or searching skills to discover relevant domain knowledge" — contradicting this bundle's own `skills-instructions.md` ("You don't need to call `load_skill(list=true)` first — skills are made visible automatically through the visibility hook") and the actual runtime behavior (the visibility hook injects the full catalog every turn regardless). Deleted the contradictory line.
- **D1** (dedup): deleted the fabricated `<available_skills>` example block in `skills-instructions.md` (wrong wrapper tag, fake skill names, missing the real `User-invoked skills (available via /command):` section and truncation marker) in favor of a two-sentence statement of the one load-bearing fact.
- **D2** (dedup): deleted the second, verbatim-duplicate copy of `load_skill`'s operations/usage in `skills-instructions.md` (already fully present in the tool's own description, which is in the payload's tool schema every turn).
- **T3** (trim): deleted the bundle-author-only material (discovery paths/precedence, `tool-skills` config schema, `config.skills` source types, the silently-ignored top-level `skills:` footgun) from `skills-instructions.md` in favor of a pointer to the `skills-assist` skill's `authoring-guide.md`, which already documents all of it.

D1+D2+T3 all touch `skills-instructions.md` and are applied as one combined change to that file (two blocks), matching the source edit set's own sequencing note.

Net: -2,536 chars / ~-685 tokens per turn for any session with this bundle mounted.

## Test status

`modules/tool-skills/tests/`: **285 passed, 2 failed** — both pre-existing and confirmed via stash-compare to be present identically before this patch (`test_enhanced_discovery.py`'s mock-resolver assertion and `test_real_session.py`'s CLI `--dry-run` flag mismatch against the installed `amplifier` CLI version; neither test references any of the content these items remove).

Root `tests/` + `skills/skillify/` + `skills/image-vision/` tests: **48 passed, 0 failed**.

## Validation evidence (1e2 context-hygiene DTU A/B treatment)

This treatment PASSED its pre-registered DTU A/B gates: 12/12 runs task-correct on both providers at n=3/arm; wire audit confirmed every deleted string absent in all treatment runs and present in all controls; measured **-5,860 chars/turn system prompt (-11.3%)** and **-1,277 chars/turn tool catalog (-4.5%)** reduction across the full treatment set; no YAML corruption in mounted agent catalogs. The openai arm showed a -45% cost delta, but that is noise-inflated at this sample size — the defensible, evidence-backed claim is the wire-byte reduction, not the cost delta.

Source of truth for the full 12-repo treatment: `treatments/1e2/MANIFEST.md` (per-repo files/items/tokens/risk table, recorded HEAD shas, APPLY.md/VERIFY.md per repo).

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
