### PR TITLE
docs: note the shared description-token budget in skills-assist authoring guide

### DIFF
--- a/skills/skills-assist/authoring-guide.md
+++ b/skills/skills-assist/authoring-guide.md
@@ -84,11 +84,13 @@ Skills are loaded lazily to conserve context. The skill loading system has three
 
 | Level | What is Loaded | Token Cost | When |
 |-------|---------------|------------|------|
-| **Metadata** | `name`, `description`, frontmatter fields only | ~100 tokens | Always — at session startup, Amplifier loads all skill metadata to populate the routing context |
+| **Metadata** | `name`, `description`, frontmatter fields only | ~100 tokens/skill (provisional ceiling: see `foundation:context/shared/description-authoring-principles.md`) | Always — at session startup, Amplifier loads all skill metadata to populate the routing context |
 | **Content** | Full `SKILL.md` body (instructions, examples, workflow) | ~1–5K tokens | On demand — when the skill is invoked by name or matched to a user request |
 | **References** | Companion files (`setup.md`, `patterns.md`, `examples/`) | 0 until read | Explicit — companion files are never auto-loaded; the skill body must call `read_file` to pull them in |
 
 **Design implication:** Put the minimum required instructions in `SKILL.md`. Move large reference material, examples, and setup docs to companion files. The forked context window only pays the cost of what it reads.
+
+**Metadata is a shared, capped budget, not a per-skill allowance.** The visibility hook renders the "Available skills" catalog under `visibility_token_budget` (default 5000 tokens) or, in legacy count-cap mode, `max_skills_visible` (default 50) -- either way every skill's `description` competes with every other visible skill's for the *same fixed budget*. At the default 50-skill cap, the current curated collection's top-50 already runs ≈ 8k tokens/session at full detail before the budget renderer starts trimming skills to name-only. A verbose description does not just cost its own author's skill -- it pushes other skills further down the detail tiers.
 
 ---
 


### PR DESCRIPTION
## Summary

Companion to microsoft/amplifier-foundation's PR encoding evidence-backed description-authoring principles. Adds a description token-ceiling reference to `skills/skills-assist/authoring-guide.md`'s progressive-disclosure table, plus one paragraph noting that skill metadata visibility is a **shared, capped budget**, not a per-skill allowance.

This guide is otherwise the model for description authoring in this repo — nothing else changed.

## Change

- Metadata row of the progressive-disclosure table now points at the canonical `foundation:context/shared/description-authoring-principles.md` for the token ceiling.
- New paragraph: the visibility hook renders the "Available skills" catalog under `visibility_token_budget` (default 5000 tokens) or, in legacy count-cap mode, `max_skills_visible` (default 50, see `modules/tool-skills/amplifier_module_tool_skills/hooks.py`). Either way, every visible skill's `description` competes with every other visible skill's for the *same fixed budget* — at the default 50-skill cap, the current curated collection's top-50 already runs ≈8k tokens/session at full detail before the budget renderer starts trimming to name-only.

## Testing

- `modules/tool-skills` test suite: **304 passed**, 1 pre-existing unrelated warning (`RuntimeWarning: coroutine ... was never awaited` in `test_race_condition_shared_cache.py`, unrelated to this docs-only change).
- Change touches only `skills/skills-assist/authoring-guide.md` — no code paths affected.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>