### PR TITLE
SCRATCH: prove the new CI can go red (do not merge)

### DIFF
--- a/.github/scripts/check_bundle_structure.py
+++ b/.github/scripts/check_bundle_structure.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Cheap structural check for this bundle: does its YAML actually parse?
+
+Run it exactly the same way CI does::
+
+    uv run --no-project --with pyyaml python .github/scripts/check_bundle_structure.py
+
+What it checks, and nothing more:
+
+1. ``bundle.md`` has a ``---`` fenced YAML frontmatter block that parses, and
+   declares ``bundle.name`` and ``bundle.version``.
+2. Every LOCAL entry in the frontmatter's ``includes:`` list resolves to a file
+   that exists on disk. Remote includes (``git+https://...``) are reported and
+   skipped -- resolving them would need the network.
+3. Every ``behaviors/*.yaml`` parses as YAML and is a non-empty mapping.
+4. Every ``skills/*/SKILL.md`` has parseable frontmatter declaring ``name`` and
+   ``description``. This is the payload of a SKILLS bundle: a skill whose
+   frontmatter does not parse is invisible at runtime, and nothing else in this
+   repo notices.
+
+Deliberate design notes:
+
+* An EMPTY glob is a FAILURE, not a pass. A check that silently returns "0
+  problems found in 0 files" is indistinguishable from a working one.
+* Paths are resolved relative to this file's own location and reported with
+  ``as_posix()`` so the output reads the same on every OS.
+* No network, no API keys, no LLM. Runs in about a second.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+problems: list[str] = []
+checked: list[str] = []
+
+
+def rel(path: Path) -> str:
+    """Repo-relative, forward-slash path -- identical output on every OS."""
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+def parse_frontmatter(text: str) -> dict | None:
+    """Return the parsed YAML frontmatter of a markdown file, or None if malformed."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
+    try:
+        end = next(i for i, line in enumerate(lines[1:], start=1) if line.strip() == "---")
+    except StopIteration:
+        return None
+    loaded = yaml.safe_load("\n".join(lines[1:end]))
+    return loaded if isinstance(loaded, dict) else None
+
+
+def resolve_include(reference: str) -> Path | None:
+    """Resolve a local ``<bundle-name>:<relative/path>`` include to a file on disk.
+
+    A behavior reference carries no extension (``skills:behaviors/skills``), so
+    the bare path and the ``.yaml`` / ``.yml`` / ``.md`` forms are all tried.
+    """
+    _, _, relative = reference.partition(":")
+    relative = relative or reference
+    base = REPO_ROOT / relative
+    for candidate in (base, base.with_suffix(".yaml"), base.with_suffix(".yml"), base.with_suffix(".md")):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+# --- 1 + 2: bundle.md frontmatter -------------------------------------------
+
+bundle_md = REPO_ROOT / "bundle.md"
+remote_includes = 0
+local_includes = 0
+
+if not bundle_md.is_file():
+    problems.append("bundle.md is missing from the repository root")
+else:
+    try:
+        parsed = parse_frontmatter(bundle_md.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        parsed = None
+        problems.append(f"{rel(bundle_md)}: frontmatter is not valid YAML: {exc}")
+
+    if parsed is None:
+        problems.append(f"{rel(bundle_md)}: no parseable '---' fenced YAML frontmatter mapping")
+    else:
+        checked.append(rel(bundle_md))
+        bundle_block = parsed.get("bundle")
+        if not isinstance(bundle_block, dict):
+            problems.append(f"{rel(bundle_md)}: frontmatter has no 'bundle:' mapping")
+        else:
+            for key in ("name", "version"):
+                if not bundle_block.get(key):
+                    problems.append(f"{rel(bundle_md)}: frontmatter is missing 'bundle.{key}'")
+
+        includes = parsed.get("includes") or []
+        if not isinstance(includes, list):
+            problems.append(f"{rel(bundle_md)}: 'includes:' must be a list, got {type(includes).__name__}")
+            includes = []
+        if not includes:
+            problems.append(f"{rel(bundle_md)}: 'includes:' is empty -- nothing was actually checked")
+        for entry in includes:
+            # Entries are mappings of one key, e.g. `- bundle: skills:behaviors/skills`.
+            reference = entry.get("bundle") if isinstance(entry, dict) else entry
+            if not isinstance(reference, str):
+                problems.append(f"{rel(bundle_md)}: includes entry is not a bundle reference: {entry!r}")
+                continue
+            if reference.startswith(("git+", "http://", "https://")):
+                remote_includes += 1
+                continue
+            local_includes += 1
+            if resolve_include(reference) is None:
+                problems.append(f"{rel(bundle_md)}: includes '{reference}' -> no such file in this repo")
+
+
+# --- 3: behaviors/*.yaml -----------------------------------------------------
+
+
+def parse_all_yaml(directory: str, pattern: str) -> int:
+    """Parse every match as a YAML mapping; return how many files were found."""
+    root = REPO_ROOT / directory
+    if not root.is_dir():
+        problems.append(f"{directory}/ directory is missing")
+        return 0
+
+    matches = sorted(root.glob(pattern))
+    if not matches:
+        # An empty glob is a failure. See the module docstring.
+        problems.append(f"{directory}/{pattern} matched NO files -- nothing was actually checked")
+        return 0
+
+    for path in matches:
+        try:
+            loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            problems.append(f"{rel(path)}: not valid YAML: {exc}")
+            continue
+        if not isinstance(loaded, dict) or not loaded:
+            problems.append(f"{rel(path)}: expected a non-empty YAML mapping, got {type(loaded).__name__}")
+            continue
+        checked.append(rel(path))
+    return len(matches)
+
+
+behaviors_count = parse_all_yaml("behaviors", "*.yaml")
+
+
+# --- 4: skills/*/SKILL.md frontmatter ---------------------------------------
+
+skills_root = REPO_ROOT / "skills"
+skill_files = sorted(skills_root.glob("*/SKILL.md")) if skills_root.is_dir() else []
+
+if not skills_root.is_dir():
+    problems.append("skills/ directory is missing")
+elif not skill_files:
+    problems.append("skills/*/SKILL.md matched NO files -- nothing was actually checked")
+else:
+    # A skill directory with no SKILL.md ships nothing; catch it explicitly
+    # rather than letting the glob quietly shrink.
+    for directory in sorted(p for p in skills_root.iterdir() if p.is_dir()):
+        if not (directory / "SKILL.md").is_file():
+            problems.append(f"{rel(directory)}/: skill directory has no SKILL.md")
+
+    for path in skill_files:
+        try:
+            parsed_skill = parse_frontmatter(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            problems.append(f"{rel(path)}: frontmatter is not valid YAML: {exc}")
+            continue
+        if parsed_skill is None:
+            problems.append(f"{rel(path)}: no parseable '---' fenced YAML frontmatter mapping")
+            continue
+        for key in ("name", "description"):
+            if not parsed_skill.get(key):
+                problems.append(f"{rel(path)}: frontmatter is missing '{key}'")
+        checked.append(rel(path))
+
+
+# --- report ------------------------------------------------------------------
+
+print(f"bundle.md frontmatter : {'ok' if bundle_md.is_file() else 'MISSING'}")
+print(f"bundle.md includes    : {local_includes} local, {remote_includes} remote (not resolved)")
+print(f"behaviors/*.yaml      : {behaviors_count} file(s)")
+print(f"skills/*/SKILL.md     : {len(skill_files)} file(s)")
+print(f"parsed cleanly        : {len(checked)} file(s)")
+
+if problems:
+    print(f"\nFAIL -- {len(problems)} problem(s):", file=sys.stderr)
+    for problem in problems:
+        print(f"  - {problem}", file=sys.stderr)
+    sys.exit(1)
+
+print("\nOK -- bundle structure checks passed")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,10 +82,13 @@ jobs:
           enable-cache: true
 
       - name: Run root tests
+        # `-ra` prints a short summary of every non-passing outcome, INCLUDING
+        # skips and their reasons. A skip is green, so without this a test that
+        # quietly stopped running looks exactly like a test that passed.
         run: >
           uv run --no-project --python ${{ matrix.python-version }}
           --with pytest
-          python -m pytest tests -q --tb=short
+          python -m pytest tests -q -ra --tb=short
 
   # ---------------------------------------------------------------------------
   # Per-module test suites. Each modules/* package owns its own pyproject.toml
@@ -139,7 +142,13 @@ jobs:
 
       - name: Run module tests
         working-directory: modules/${{ matrix.module }}
-        run: uv run --frozen --extra remote-sources python -m pytest -q --tb=short
+        # `-ra` is load-bearing here: tests/test_real_session.py is an
+        # integration smoke against the installed `amplifier` CLI, which is a
+        # separate application and is legitimately absent on a runner. It skips
+        # itself with a reason, and `-ra` puts that reason in the job log so the
+        # skip is visible rather than passing for coverage. Expect exactly one
+        # skip on a stock runner: 314 passed, 1 skipped.
+        run: uv run --frozen --extra remote-sources python -m pytest -q -ra --tb=short
 
   # ---------------------------------------------------------------------------
   # Bundle structure — a cheap YAML parse of bundle.md's frontmatter, every

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,164 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Minimal read-only token — no secrets needed or exposed.
+# Safe for Dependabot PRs and external fork contributors.
+#
+# NOTE: nothing in this workflow calls an LLM. Skills are prose, and the
+# temptation is to "validate" them with a model — that needs API keys and costs
+# money per run, so it is deliberately NOT wired here. Everything below is free,
+# offline apart from dependency resolution, and finishes in about two minutes.
+#
+# There are NO path filters, NO `continue-on-error` and NO `|| true` anywhere in
+# this file, on purpose. Each of those is a way for a run to be green vacuously.
+permissions:
+  contents: read
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Lint — ruff, at a PINNED version.
+  #
+  # The version pin is load-bearing, not fussiness. "ruff's default rules" is a
+  # moving target, so an unpinned linter turns an unrelated upstream release
+  # into a red PR nobody changed anything to cause. 0.15.7 is the version this
+  # repo's own committed lockfile resolves (modules/tool-skills/uv.lock), so CI
+  # lints with exactly the ruff a contributor gets from `uv sync` there.
+  #
+  # Rule selection lives in ruff.toml at the repo root, so this is byte-for-byte
+  # the command a contributor runs locally.
+  #
+  # `ruff format --check` is NOT wired here, on purpose. This repo has never
+  # been ruff-formatted: at 0.15.7 defaults, `ruff format` would rewrite 19 of
+  # 56 files. That is a whitespace-normalisation change, and it does not belong
+  # in the PR that introduces CI — it would collide with every in-flight branch.
+  # Naming it here so the next contributor sees a decision rather than an
+  # oversight; wiring it is a follow-up and the diff is purely mechanical:
+  # `uvx ruff@0.15.7 format .`
+  # ---------------------------------------------------------------------------
+  lint:
+    name: Lint (ruff)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+        with:
+          enable-cache: true
+
+      - name: Lint
+        run: uvx ruff@0.15.7 check .
+
+  # ---------------------------------------------------------------------------
+  # Repo-root test suite (tests/) across supported Python versions.
+  #
+  # There is no root pyproject.toml or lockfile — this repo is a BUNDLE, not a
+  # Python package, and only modules/* are installable. So the root suite runs
+  # in an ephemeral uv environment with its one actual dependency, pytest. The
+  # root tests read files (bundle.md, skills/*/SKILL.md, the tool-skills source)
+  # with pathlib and re; they import nothing from this repo, so nothing needs
+  # installing.
+  # ---------------------------------------------------------------------------
+  test-root:
+    name: Tests — root (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+        with:
+          enable-cache: true
+
+      - name: Run root tests
+        run: >
+          uv run --no-project --python ${{ matrix.python-version }}
+          --with pytest
+          python -m pytest tests -q --tb=short
+
+  # ---------------------------------------------------------------------------
+  # Per-module test suites. Each modules/* package owns its own pyproject.toml
+  # and uv.lock, so each gets its own matrix leg — add a directory name here
+  # when a second module lands.
+  #
+  # TWO non-obvious things, both of which silently weaken this job if dropped:
+  #
+  # 1. `--extra remote-sources` is REQUIRED, not optional. amplifier-foundation
+  #    is a runtime dependency resolved by amplifier's module system rather than
+  #    by the module's core dependencies, so it sits in an optional extra. A
+  #    plain `uv sync --frozen` + pytest here ABORTS COLLECTION:
+  #    `ModuleNotFoundError: No module named 'amplifier_foundation'` — measured
+  #    on this tree. With the extra: 315 passed.
+  #
+  # 2. `python -m pytest`, NOT `pytest`. The `pytest` console script does not
+  #    reliably see packages supplied by uv overlays, and this repo's sibling
+  #    bundle measured 14 spurious ModuleNotFoundError failures that way.
+  #    `python -m pytest` sees the environment that was actually built.
+  # ---------------------------------------------------------------------------
+  test-modules:
+    name: Tests — modules/${{ matrix.module }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          - tool-skills
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+        with:
+          enable-cache: true
+
+      - name: Install module dependencies
+        working-directory: modules/${{ matrix.module }}
+        # --frozen: use the module's committed lockfile exactly as-is; fail if
+        # it would need updating. This ensures Dependabot bumps are tested
+        # as-proposed rather than silently re-resolved.
+        run: uv sync --frozen --extra remote-sources
+
+      - name: Assert test fixtures are present (they gate 9 tests)
+        working-directory: modules/${{ matrix.module }}
+        # Nine tests call `pytest.skip("Fixtures directory not found")` when
+        # tests/fixtures/skills is absent. A skip is GREEN, so a future move of
+        # that directory would quietly delete nine tests' worth of coverage
+        # without ever turning a run red. This step converts that into a
+        # failure the moment it happens.
+        run: test -d tests/fixtures/skills
+
+      - name: Run module tests
+        working-directory: modules/${{ matrix.module }}
+        run: uv run --frozen --extra remote-sources python -m pytest -q --tb=short
+
+  # ---------------------------------------------------------------------------
+  # Bundle structure — a cheap YAML parse of bundle.md's frontmatter, every
+  # behaviors/*.yaml, and every skills/*/SKILL.md. No network, no keys, ~1s.
+  #
+  # SKILL.md frontmatter is the payload of a SKILLS bundle: a skill whose
+  # frontmatter does not parse is invisible at runtime, and nothing else in this
+  # repo notices. The script treats an EMPTY glob as a failure — a check that
+  # reports "0 problems in 0 files" and exits 0 looks exactly like a working one.
+  # ---------------------------------------------------------------------------
+  bundle-structure:
+    name: Bundle structure
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+        with:
+          enable-cache: true
+
+      - name: Check bundle structure
+        run: uv run --no-project --with pyyaml python .github/scripts/check_bundle_structure.py

--- a/docs/lanes/z6wa-skills-visibility-renderer/deliverables_check.py
+++ b/docs/lanes/z6wa-skills-visibility-renderer/deliverables_check.py
@@ -59,9 +59,9 @@ def d2_template_not_hardcoded() -> None:
     v1_block = json.loads(V1.read_text())[11]["new"]
     # No fragment of the captured v1 text may be baked into the renderer.
     v1_lines = [
-        l for l in v1_block.split("\n") if l.startswith("- **") and len(l) > 60
+        line for line in v1_block.split("\n") if line.startswith("- **") and len(line) > 60
     ]
-    leaked = [l for l in v1_lines if l.strip() in src]
+    leaked = [line for line in v1_lines if line.strip() in src]
     # And the block must be assembled from parts, not returned as one literal.
     assembles = 'f"- **{name}**: ' in src or '"- **{name}**: ' in src
     note = NOTE.read_text()

--- a/docs/lanes/z6wa-skills-visibility-renderer/shape_conformance.py
+++ b/docs/lanes/z6wa-skills-visibility-renderer/shape_conformance.py
@@ -154,7 +154,7 @@ def main() -> int:
 
     v1_block = json.loads(V1.read_text())[11]["new"].rstrip("\n")
     v1_names = [
-        m.group(1) for m in (SKILL_LINE.match(l) for l in v1_block.split("\n")) if m
+        m.group(1) for m in (SKILL_LINE.match(line) for line in v1_block.split("\n")) if m
     ]
 
     print("=" * 74)

--- a/modules/tool-skills/tests/test_ci_red_proof_DELETEME.py
+++ b/modules/tool-skills/tests/test_ci_red_proof_DELETEME.py
@@ -1,0 +1,9 @@
+"""DELIBERATE FAILURE — scratch-branch only, never merged.
+
+Companion to tests/test_ci_red_proof_DELETEME.py, for the module suite. Expect
+the modules/tool-skills job to report "315 passed, 1 failed".
+"""
+
+
+def test_ci_can_go_red_module_suite():
+    assert 1 == 2, "deliberate failure: proving the tool-skills suite really executes in CI"

--- a/modules/tool-skills/tests/test_real_session.py
+++ b/modules/tool-skills/tests/test_real_session.py
@@ -1,13 +1,34 @@
-"""Test that skills are visible in actual amplifier sessions."""
+"""Test that skills are visible in actual amplifier sessions.
+
+This is an INTEGRATION smoke against the installed `amplifier` CLI, not a unit
+test of this module. The CLI is a separate application (microsoft/amplifier-app-cli)
+and is deliberately not a dependency of amplifier-module-tool-skills, so it is
+absent on a clean machine -- including a CI runner. Before the guard below, this
+module shelled out to it unconditionally and died with
+`FileNotFoundError: [Errno 2] No such file or directory: 'amplifier'`; it only
+ever passed because the developer running it happened to have the CLI on PATH.
+
+The skip is reported explicitly (CI runs pytest with `-ra`), so a run where this
+test does not execute says so in the job log rather than looking like coverage.
+"""
 
 import os
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 
+import pytest
+
 
 def test_skills_visible_in_session():
     """Verify skills are visible when running amplifier with the skills bundle."""
+
+    if shutil.which("amplifier") is None:
+        pytest.skip(
+            "the `amplifier` CLI is not on PATH -- this is an integration smoke "
+            "against the installed application, which is not a dependency of this module"
+        )
 
     # Create a test skill
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -59,6 +80,4 @@ This skill should be visible to the agent.""")
 
 
 if __name__ == "__main__":
-    import os
-
     test_skills_visible_in_session()

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,19 @@
+# Ruff configuration for amplifier-bundle-skills.
+#
+# This file exists so `ruff check .` means the SAME thing locally and in CI.
+# Without it, ruff walks up the filesystem looking for a config and can pick up
+# an unrelated parent-directory pyproject.toml -- which is how a local run and a
+# CI run silently disagree about which rules are even enabled. There is no root
+# pyproject.toml here (this repo is a BUNDLE, not a Python package), and
+# modules/tool-skills/pyproject.toml carries no [tool.ruff] block, so without
+# this file NOTHING in the repo has a pinned lint configuration.
+#
+# Settings match the sibling bundle repos microsoft/amplifier-bundle-routing-matrix
+# and microsoft/amplifier-bundle-context-intelligence, so the bundles lint alike.
+#
+# Rule selection is ruff's default (E4, E7, E9, F). CI pins the ruff VERSION
+# (see .github/workflows/ci.yml) because "default rules" is a moving target: a
+# linter that is not version-pinned turns an unrelated upstream release into a
+# red PR nobody changed anything to cause.
+target-version = "py311"
+line-length = 100

--- a/tests/test_ci_red_proof_DELETEME.py
+++ b/tests/test_ci_red_proof_DELETEME.py
@@ -1,0 +1,11 @@
+"""DELIBERATE FAILURE — scratch-branch only, never merged.
+
+Exists to prove this repo's brand-new CI can actually go RED, and that the red
+comes from the TEST job running the real suite rather than from a setup or lint
+error (which would prove nothing). Expect the root job to report
+"27 passed, 1 failed".
+"""
+
+
+def test_ci_can_go_red_root_suite():
+    assert 1 == 2, "deliberate failure: proving the root suite really executes in CI"


### PR DESCRIPTION
Throwaway branch. One deliberately failing assertion in each suite, to observe a RED run whose job log shows the real suite EXECUTING alongside the failure — not a setup or lint error.

Expect: `Tests — root` = 27 passed, 1 failed; `Tests — modules/tool-skills` = 315 passed, 1 failed; `Lint` and `Bundle structure` green.

Closed and the branch deleted as soon as the red run is recorded.