### PR TITLE
ci: add CI — ruff (pinned) + root/module pytest + bundle-structure check, proven red-then-green

### DIFF
--- a/.github/scripts/check_bundle_structure.py
+++ b/.github/scripts/check_bundle_structure.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Cheap structural check for this bundle: does its YAML actually parse?
+
+Run it exactly the same way CI does::
+
+    uv run --no-project --with pyyaml python .github/scripts/check_bundle_structure.py
+
+What it checks, and nothing more:
+
+1. ``bundle.md`` has a ``---`` fenced YAML frontmatter block that parses, and
+   declares ``bundle.name`` and ``bundle.version``.
+2. Every LOCAL entry in the frontmatter's ``includes:`` list resolves to a file
+   that exists on disk. Remote includes (``git+https://...``) are reported and
+   skipped -- resolving them would need the network.
+3. Every ``behaviors/*.yaml`` parses as YAML and is a non-empty mapping.
+4. Every ``skills/*/SKILL.md`` has parseable frontmatter declaring ``name`` and
+   ``description``. This is the payload of a SKILLS bundle: a skill whose
+   frontmatter does not parse is invisible at runtime, and nothing else in this
+   repo notices.
+
+Deliberate design notes:
+
+* An EMPTY glob is a FAILURE, not a pass. A check that silently returns "0
+  problems found in 0 files" is indistinguishable from a working one.
+* Paths are resolved relative to this file's own location and reported with
+  ``as_posix()`` so the output reads the same on every OS.
+* No network, no API keys, no LLM. Runs in about a second.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+problems: list[str] = []
+checked: list[str] = []
+
+
+def rel(path: Path) -> str:
+    """Repo-relative, forward-slash path -- identical output on every OS."""
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+def parse_frontmatter(text: str) -> dict | None:
+    """Return the parsed YAML frontmatter of a markdown file, or None if malformed."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
+    try:
+        end = next(i for i, line in enumerate(lines[1:], start=1) if line.strip() == "---")
+    except StopIteration:
+        return None
+    loaded = yaml.safe_load("\n".join(lines[1:end]))
+    return loaded if isinstance(loaded, dict) else None
+
+
+def resolve_include(reference: str) -> Path | None:
+    """Resolve a local ``<bundle-name>:<relative/path>`` include to a file on disk.
+
+    A behavior reference carries no extension (``skills:behaviors/skills``), so
+    the bare path and the ``.yaml`` / ``.yml`` / ``.md`` forms are all tried.
+    """
+    _, _, relative = reference.partition(":")
+    relative = relative or reference
+    base = REPO_ROOT / relative
+    for candidate in (base, base.with_suffix(".yaml"), base.with_suffix(".yml"), base.with_suffix(".md")):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+# --- 1 + 2: bundle.md frontmatter -------------------------------------------
+
+bundle_md = REPO_ROOT / "bundle.md"
+remote_includes = 0
+local_includes = 0
+
+if not bundle_md.is_file():
+    problems.append("bundle.md is missing from the repository root")
+else:
+    try:
+        parsed = parse_frontmatter(bundle_md.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        parsed = None
+        problems.append(f"{rel(bundle_md)}: frontmatter is not valid YAML: {exc}")
+
+    if parsed is None:
+        problems.append(f"{rel(bundle_md)}: no parseable '---' fenced YAML frontmatter mapping")
+    else:
+        checked.append(rel(bundle_md))
+        bundle_block = parsed.get("bundle")
+        if not isinstance(bundle_block, dict):
+            problems.append(f"{rel(bundle_md)}: frontmatter has no 'bundle:' mapping")
+        else:
+            for key in ("name", "version"):
+                if not bundle_block.get(key):
+                    problems.append(f"{rel(bundle_md)}: frontmatter is missing 'bundle.{key}'")
+
+        includes = parsed.get("includes") or []
+        if not isinstance(includes, list):
+            problems.append(f"{rel(bundle_md)}: 'includes:' must be a list, got {type(includes).__name__}")
+            includes = []
+        if not includes:
+            problems.append(f"{rel(bundle_md)}: 'includes:' is empty -- nothing was actually checked")
+        for entry in includes:
+            # Entries are mappings of one key, e.g. `- bundle: skills:behaviors/skills`.
+            reference = entry.get("bundle") if isinstance(entry, dict) else entry
+            if not isinstance(reference, str):
+                problems.append(f"{rel(bundle_md)}: includes entry is not a bundle reference: {entry!r}")
+                continue
+            if reference.startswith(("git+", "http://", "https://")):
+                remote_includes += 1
+                continue
+            local_includes += 1
+            if resolve_include(reference) is None:
+                problems.append(f"{rel(bundle_md)}: includes '{reference}' -> no such file in this repo")
+
+
+# --- 3: behaviors/*.yaml -----------------------------------------------------
+
+
+def parse_all_yaml(directory: str, pattern: str) -> int:
+    """Parse every match as a YAML mapping; return how many files were found."""
+    root = REPO_ROOT / directory
+    if not root.is_dir():
+        problems.append(f"{directory}/ directory is missing")
+        return 0
+
+    matches = sorted(root.glob(pattern))
+    if not matches:
+        # An empty glob is a failure. See the module docstring.
+        problems.append(f"{directory}/{pattern} matched NO files -- nothing was actually checked")
+        return 0
+
+    for path in matches:
+        try:
+            loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            problems.append(f"{rel(path)}: not valid YAML: {exc}")
+            continue
+        if not isinstance(loaded, dict) or not loaded:
+            problems.append(f"{rel(path)}: expected a non-empty YAML mapping, got {type(loaded).__name__}")
+            continue
+        checked.append(rel(path))
+    return len(matches)
+
+
+behaviors_count = parse_all_yaml("behaviors", "*.yaml")
+
+
+# --- 4: skills/*/SKILL.md frontmatter ---------------------------------------
+
+skills_root = REPO_ROOT / "skills"
+skill_files = sorted(skills_root.glob("*/SKILL.md")) if skills_root.is_dir() else []
+
+if not skills_root.is_dir():
+    problems.append("skills/ directory is missing")
+elif not skill_files:
+    problems.append("skills/*/SKILL.md matched NO files -- nothing was actually checked")
+else:
+    # A skill directory with no SKILL.md ships nothing; catch it explicitly
+    # rather than letting the glob quietly shrink.
+    for directory in sorted(p for p in skills_root.iterdir() if p.is_dir()):
+        if not (directory / "SKILL.md").is_file():
+            problems.append(f"{rel(directory)}/: skill directory has no SKILL.md")
+
+    for path in skill_files:
+        try:
+            parsed_skill = parse_frontmatter(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            problems.append(f"{rel(path)}: frontmatter is not valid YAML: {exc}")
+            continue
+        if parsed_skill is None:
+            problems.append(f"{rel(path)}: no parseable '---' fenced YAML frontmatter mapping")
+            continue
+        for key in ("name", "description"):
+            if not parsed_skill.get(key):
+                problems.append(f"{rel(path)}: frontmatter is missing '{key}'")
+        checked.append(rel(path))
+
+
+# --- report ------------------------------------------------------------------
+
+print(f"bundle.md frontmatter : {'ok' if bundle_md.is_file() else 'MISSING'}")
+print(f"bundle.md includes    : {local_includes} local, {remote_includes} remote (not resolved)")
+print(f"behaviors/*.yaml      : {behaviors_count} file(s)")
+print(f"skills/*/SKILL.md     : {len(skill_files)} file(s)")
+print(f"parsed cleanly        : {len(checked)} file(s)")
+
+if problems:
+    print(f"\nFAIL -- {len(problems)} problem(s):", file=sys.stderr)
+    for problem in problems:
+        print(f"  - {problem}", file=sys.stderr)
+    sys.exit(1)
+
+print("\nOK -- bundle structure checks passed")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,16 @@ jobs:
         # itself with a reason, and `-ra` puts that reason in the job log so the
         # skip is visible rather than passing for coverage. Expect exactly one
         # skip on a stock runner: 314 passed, 1 skipped.
-        run: uv run --frozen --extra remote-sources python -m pytest -q -ra --tb=short
+        #
+        # `-v` instead of `-q` is load-bearing for the same reason. Under `-q`
+        # a green log reports only an aggregate ("314 passed, 1 skipped"), which
+        # cannot show that any PARTICULAR guard ran — a deleted or renamed test
+        # just makes the aggregate smaller, and the run stays green. `-v` prints
+        # one `path::test_name PASSED` line per test, so the visibility guards
+        # (tests/test_visibility_budget.py and tests/test_visibility_line_cap.py)
+        # are named in the log of every green run. The suite itself is unchanged
+        # and still runs in full: this only changes what the log reports.
+        run: uv run --frozen --extra remote-sources python -m pytest -v -ra --tb=short
 
   # ---------------------------------------------------------------------------
   # Bundle structure — a cheap YAML parse of bundle.md's frontmatter, every

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,10 +82,13 @@ jobs:
           enable-cache: true
 
       - name: Run root tests
+        # `-ra` prints a short summary of every non-passing outcome, INCLUDING
+        # skips and their reasons. A skip is green, so without this a test that
+        # quietly stopped running looks exactly like a test that passed.
         run: >
           uv run --no-project --python ${{ matrix.python-version }}
           --with pytest
-          python -m pytest tests -q --tb=short
+          python -m pytest tests -q -ra --tb=short
 
   # ---------------------------------------------------------------------------
   # Per-module test suites. Each modules/* package owns its own pyproject.toml
@@ -139,7 +142,13 @@ jobs:
 
       - name: Run module tests
         working-directory: modules/${{ matrix.module }}
-        run: uv run --frozen --extra remote-sources python -m pytest -q --tb=short
+        # `-ra` is load-bearing here: tests/test_real_session.py is an
+        # integration smoke against the installed `amplifier` CLI, which is a
+        # separate application and is legitimately absent on a runner. It skips
+        # itself with a reason, and `-ra` puts that reason in the job log so the
+        # skip is visible rather than passing for coverage. Expect exactly one
+        # skip on a stock runner: 314 passed, 1 skipped.
+        run: uv run --frozen --extra remote-sources python -m pytest -q -ra --tb=short
 
   # ---------------------------------------------------------------------------
   # Bundle structure — a cheap YAML parse of bundle.md's frontmatter, every

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,164 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Minimal read-only token — no secrets needed or exposed.
+# Safe for Dependabot PRs and external fork contributors.
+#
+# NOTE: nothing in this workflow calls an LLM. Skills are prose, and the
+# temptation is to "validate" them with a model — that needs API keys and costs
+# money per run, so it is deliberately NOT wired here. Everything below is free,
+# offline apart from dependency resolution, and finishes in about two minutes.
+#
+# There are NO path filters, NO `continue-on-error` and NO `|| true` anywhere in
+# this file, on purpose. Each of those is a way for a run to be green vacuously.
+permissions:
+  contents: read
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Lint — ruff, at a PINNED version.
+  #
+  # The version pin is load-bearing, not fussiness. "ruff's default rules" is a
+  # moving target, so an unpinned linter turns an unrelated upstream release
+  # into a red PR nobody changed anything to cause. 0.15.7 is the version this
+  # repo's own committed lockfile resolves (modules/tool-skills/uv.lock), so CI
+  # lints with exactly the ruff a contributor gets from `uv sync` there.
+  #
+  # Rule selection lives in ruff.toml at the repo root, so this is byte-for-byte
+  # the command a contributor runs locally.
+  #
+  # `ruff format --check` is NOT wired here, on purpose. This repo has never
+  # been ruff-formatted: at 0.15.7 defaults, `ruff format` would rewrite 19 of
+  # 56 files. That is a whitespace-normalisation change, and it does not belong
+  # in the PR that introduces CI — it would collide with every in-flight branch.
+  # Naming it here so the next contributor sees a decision rather than an
+  # oversight; wiring it is a follow-up and the diff is purely mechanical:
+  # `uvx ruff@0.15.7 format .`
+  # ---------------------------------------------------------------------------
+  lint:
+    name: Lint (ruff)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+        with:
+          enable-cache: true
+
+      - name: Lint
+        run: uvx ruff@0.15.7 check .
+
+  # ---------------------------------------------------------------------------
+  # Repo-root test suite (tests/) across supported Python versions.
+  #
+  # There is no root pyproject.toml or lockfile — this repo is a BUNDLE, not a
+  # Python package, and only modules/* are installable. So the root suite runs
+  # in an ephemeral uv environment with its one actual dependency, pytest. The
+  # root tests read files (bundle.md, skills/*/SKILL.md, the tool-skills source)
+  # with pathlib and re; they import nothing from this repo, so nothing needs
+  # installing.
+  # ---------------------------------------------------------------------------
+  test-root:
+    name: Tests — root (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+        with:
+          enable-cache: true
+
+      - name: Run root tests
+        run: >
+          uv run --no-project --python ${{ matrix.python-version }}
+          --with pytest
+          python -m pytest tests -q --tb=short
+
+  # ---------------------------------------------------------------------------
+  # Per-module test suites. Each modules/* package owns its own pyproject.toml
+  # and uv.lock, so each gets its own matrix leg — add a directory name here
+  # when a second module lands.
+  #
+  # TWO non-obvious things, both of which silently weaken this job if dropped:
+  #
+  # 1. `--extra remote-sources` is REQUIRED, not optional. amplifier-foundation
+  #    is a runtime dependency resolved by amplifier's module system rather than
+  #    by the module's core dependencies, so it sits in an optional extra. A
+  #    plain `uv sync --frozen` + pytest here ABORTS COLLECTION:
+  #    `ModuleNotFoundError: No module named 'amplifier_foundation'` — measured
+  #    on this tree. With the extra: 315 passed.
+  #
+  # 2. `python -m pytest`, NOT `pytest`. The `pytest` console script does not
+  #    reliably see packages supplied by uv overlays, and this repo's sibling
+  #    bundle measured 14 spurious ModuleNotFoundError failures that way.
+  #    `python -m pytest` sees the environment that was actually built.
+  # ---------------------------------------------------------------------------
+  test-modules:
+    name: Tests — modules/${{ matrix.module }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          - tool-skills
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+        with:
+          enable-cache: true
+
+      - name: Install module dependencies
+        working-directory: modules/${{ matrix.module }}
+        # --frozen: use the module's committed lockfile exactly as-is; fail if
+        # it would need updating. This ensures Dependabot bumps are tested
+        # as-proposed rather than silently re-resolved.
+        run: uv sync --frozen --extra remote-sources
+
+      - name: Assert test fixtures are present (they gate 9 tests)
+        working-directory: modules/${{ matrix.module }}
+        # Nine tests call `pytest.skip("Fixtures directory not found")` when
+        # tests/fixtures/skills is absent. A skip is GREEN, so a future move of
+        # that directory would quietly delete nine tests' worth of coverage
+        # without ever turning a run red. This step converts that into a
+        # failure the moment it happens.
+        run: test -d tests/fixtures/skills
+
+      - name: Run module tests
+        working-directory: modules/${{ matrix.module }}
+        run: uv run --frozen --extra remote-sources python -m pytest -q --tb=short
+
+  # ---------------------------------------------------------------------------
+  # Bundle structure — a cheap YAML parse of bundle.md's frontmatter, every
+  # behaviors/*.yaml, and every skills/*/SKILL.md. No network, no keys, ~1s.
+  #
+  # SKILL.md frontmatter is the payload of a SKILLS bundle: a skill whose
+  # frontmatter does not parse is invisible at runtime, and nothing else in this
+  # repo notices. The script treats an EMPTY glob as a failure — a check that
+  # reports "0 problems in 0 files" and exits 0 looks exactly like a working one.
+  # ---------------------------------------------------------------------------
+  bundle-structure:
+    name: Bundle structure
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+        with:
+          enable-cache: true
+
+      - name: Check bundle structure
+        run: uv run --no-project --with pyyaml python .github/scripts/check_bundle_structure.py

--- a/docs/lanes/j1e6-ci-skills/DONE-NOTE.md
+++ b/docs/lanes/j1e6-ci-skills/DONE-NOTE.md
@@ -1,0 +1,172 @@
+# Lane j1e6-ci-skills — DONE-NOTE
+
+**Item:** `model_performance-2un7` — CI for `microsoft/amplifier-bundle-skills` (had none).
+**Outcome branch: A (RESOLVED).** Every deliverable is DONE. No deliverable was cap-bound.
+**Terminal word: RESOLVED.**
+
+**PR:** https://github.com/microsoft/amplifier-bundle-skills/pull/68 (open, ready for review,
+NOT merged — the manager merges).
+
+---
+
+## Deliverables
+
+| # | Deliverable | State |
+|---|---|---|
+| 1 | `.github/workflows/ci.yml` running the real suite, ruff pinned, push:main + pull_request, no path filters / `continue-on-error` / `\|\| true` | **DONE** |
+| 2 | Both run URLs quoted in the PR body; the RED one's job log shows the suite executing with a genuine **test** failure | **DONE** |
+| 3 | Scratch PR closed and branch deleted — **verified**, not assumed | **DONE** |
+| 4 | A statement of what the suite actually covers | **DONE** — see "Coverage" below. This repo has real tests; the labelled import-smoke fallback was not needed |
+| 5 | Clean main red → STOP, report, fix as separate named commits | **DONE** — it was red **twice**; both fixed as their own commits (below) |
+| 6 | Draft PR, marked ready when green, not merged | **DONE** |
+
+## The CI
+
+Four jobs, all free — no API keys, no LLM, ~2 min wall clock:
+
+| Job | Command | Scale |
+|---|---|---|
+| `Lint (ruff)` | `uvx ruff@0.15.7 check .` | whole repo |
+| `Tests — root` | `python -m pytest tests -q -ra --tb=short` on 3.11 / 3.12 / 3.13 | 27 tests |
+| `Tests — modules/tool-skills` | `uv sync --frozen --extra remote-sources` then `python -m pytest -q -ra --tb=short` | 315 tests |
+| `Bundle structure` | `.github/scripts/check_bundle_structure.py` | 41 YAML surfaces |
+
+Plus `ruff.toml` at the repo root — without it *nothing* here pins a lint configuration (no
+root `pyproject.toml`; `modules/tool-skills/pyproject.toml` has no `[tool.ruff]`), so
+`ruff check .` walks up out of the repo looking for one and local/CI can silently disagree.
+
+Shape taken: the **bundle-with-`modules/`** template
+(`microsoft/amplifier-bundle-context-intelligence` per-module install + pytest, plus the
+bundle-structure YAML parse), adapted with the no-root-package handling that
+`microsoft/amplifier-bundle-routing-matrix` (`b4xs`) worked out — ephemeral `uv run
+--no-project` for the root suite, since this repo is a bundle, not a Python package. All three
+GitHub Actions pinned to full commit SHAs, each verified to be the SHA its version tag points
+at (`gh api repos/<a>/git/ref/tags/<v>`).
+
+## Coverage — what the suite actually covers
+
+**342 tests total.** 341 execute on a stock runner; 1 skips with a printed reason.
+
+- **Root `tests/` — 27 tests**, all file-reading assertions (pathlib + re, no imports from this
+  repo): `.gitignore` contents, `bundle.md`'s foundation include, the `adapt-skill` SKILL.md
+  structure, and the lean-head size/content pins from `smy5`.
+- **`modules/tool-skills/tests/` — 315 tests**, the real unit suite for the `load_skill` tool:
+  discovery, multi-source resolution, preprocessing, fork context inheritance, model-role
+  resolution, the hook integration, and — the reason this lane exists — `#66`'s
+  `test_visibility_budget.py` and `test_visibility_line_cap.py`, **which nothing had ever
+  executed before this PR**.
+- **1 skipped:** `tests/test_real_session.py::test_skills_visible_in_session` — see finding 2.
+- **Bundle structure:** `bundle.md` frontmatter (+ its local include resolving to a real file),
+  both `behaviors/*.yaml`, and all **38** `skills/*/SKILL.md` frontmatter blocks parsed and
+  checked for `name` + `description`. An empty glob is a **failure**, not a pass.
+
+The structure script was itself proven to fail: appending `a: [unclosed` to
+`behaviors/skills.yaml` produced `FAIL -- 1 problem(s)` and exit 1; restoring it returned exit 0.
+
+## The non-negotiable gate — the CI has been seen red
+
+Scratch branch `scratch/j1e6-ci-red-proof`, one deliberately failing assertion in **each** suite,
+draft PR #67.
+
+**RED run:** https://github.com/microsoft/amplifier-bundle-skills/actions/runs/34156222957
+(head `a75782262d056cae722b0fe11ff076d4b2f28d6b` — the exact workflow being shipped)
+
+```
+success  Lint (ruff)
+success  Bundle structure
+failure  Tests — modules/tool-skills : 1 failed, 314 passed, 1 skipped in 1.38s
+failure  Tests — root (3.11)         : 1 failed, 27 passed in 0.06s
+failure  Tests — root (3.12)         : 1 failed, 27 passed in 0.07s
+failure  Tests — root (3.13)         : 1 failed, 27 passed in 0.05s
+```
+
+Lint and Bundle structure stayed **green** while the test jobs went red — so the red came from
+the test job running the real suite, not from a setup or lint error, which would have proved
+nothing. Full excerpts: `red-run-evidence.txt` beside this note.
+
+An earlier red run on the same branch (34155658273) used the pre-`-ra` workflow and is what
+surfaced finding 2; the branch was rebased onto the corrected workflow and re-run so the
+quoted red is of the exact file being merged.
+
+**Scratch cleanup — verified, not assumed:** PR #67 `state: CLOSED`;
+`git ls-remote --heads origin 'scratch/*'` returns **nothing**.
+
+**GREEN run:** https://github.com/microsoft/amplifier-bundle-skills/actions/runs/34156726801 —
+all six jobs green on `fbeb717a4b2586912b184bf6f3a3529cb972f7be`.
+
+## Clean main was red — twice. Neither papered over.
+
+**Finding 1 — `ruff check .`: 3 genuine E741 findings on untouched main.** Ambiguous variable
+name `l` in two archived lane-artifact scripts under
+`docs/lanes/z6wa-skills-visibility-renderer/`. Fixed as its own commit (`fix(lint):`) with pure
+loop-variable renames. Excluding `docs/` or narrowing the rule selection would have been the
+same vacuous-green move as `continue-on-error`, so neither was done.
+
+**Finding 2 — `tests/test_real_session.py` dies on any clean checkout.** Found by the first
+red-proof run:
+
+```
+FAILED tests/test_real_session.py::test_skills_visible_in_session
+  - FileNotFoundError: [Errno 2] No such file or directory: 'amplifier'
+```
+
+The test shells out to the `amplifier` CLI — a separate application
+(`microsoft/amplifier-app-cli`) that is deliberately **not** a dependency of
+`amplifier-module-tool-skills`. The dependency was never declared, so the test only ever passed
+on a machine where the developer happened to have the CLI installed. This is the single most
+useful thing this lane found: it was invisible precisely *because* there was no CI.
+
+Fixed as its own commit (`fix(tests):`) by making the dependency explicit —
+`shutil.which("amplifier")` → skip with a reason naming why. **Rejected alternative:**
+installing app-cli from git in the module job, which would couple this module's CI to another
+repo's `main` — the same "unrelated upstream change turns your PR red" failure mode the pinned
+ruff version exists to avoid.
+
+Because **a skip is green**, both test jobs now run pytest with `-ra`, printing every
+non-passing outcome and its reason into the job log. Verified present in both the red and green
+runs:
+
+```
+SKIPPED [1] tests/test_real_session.py:28: the `amplifier` CLI is not on PATH -- ...
+```
+
+## Decisions taken without asking (no human wait)
+
+1. **ruff pinned to 0.15.7**, not routing-matrix's 0.15.11 — 0.15.7 is what this repo's own
+   committed `modules/tool-skills/uv.lock` resolves, so CI lints with exactly the ruff a
+   contributor gets from `uv sync` there. Both versions report identically on this tree
+   (3 findings before the fix, 0 after), so the choice costs nothing and buys local/CI identity.
+2. **`ruff format --check` NOT wired.** At 0.15.7 defaults it would rewrite **19 of 56 files**.
+   That whitespace normalisation does not belong in the PR introducing CI — it would collide
+   with every in-flight branch. Named in the workflow so the next contributor sees a decision,
+   not an oversight.
+3. **No LLM-backed validation**, per the item. Skills are prose and the temptation is real, but
+   it needs keys and costs money per run.
+4. **Two guards added that the template did not have**, each converting a silent weakening into
+   a red run: `test -d tests/fixtures/skills` (nine tests self-skip without it), and `-ra` on
+   both pytest invocations.
+5. **`skills/*/SKILL.md` frontmatter added to the structure check** beyond the item's stated
+   `bundle.md` + `behaviors/*.yaml`. It is the payload of a *skills* bundle: a skill whose
+   frontmatter does not parse is invisible at runtime and nothing else in this repo notices.
+6. **`uv sync --frozen --extra remote-sources` is mandatory**, measured: without the extra,
+   `amplifier_foundation` is missing and pytest **aborts collection** rather than failing a test.
+
+## Spend
+
+**$0.00 of a $0.00 authority.** Arithmetic as stated in the goal: `0 runs x 0 arms x $0 / 1.00
+= $0.00`, slack `$0.00`. This deliverable buys no API calls, no DTU, no containers — GitHub
+Actions minutes only, which the authority explicitly permits. **The arithmetic closes**: the
+deliverable's cost is structurally zero, so there is no cap-bound gap and no OUTCOME-branch-B
+finding to report. No API keys were used, no infrastructure was created, so nothing was
+registered in the infra ledger and nothing needed tearing down.
+
+CI minutes actually consumed: 3 runs x 6 jobs (~2 min wall clock each run).
+
+## What remains open (for whoever picks this up)
+
+1. **The merge.** Procedure 4 forbids this lane to merge; PR #68 is ready for review. After
+   merge, confirm `main` HEAD reports a successful check-run — *configured is not installed*.
+2. **`ruff format`** is a mechanical follow-up: `uvx ruff@0.15.7 format .`, 19 files.
+3. **`test_real_session.py` now skips in CI.** If the amplifier CLI smoke is considered
+   load-bearing, the honest way to restore it is a separate job that installs app-cli
+   explicitly — with eyes open about coupling this repo's CI to another repo's `main`.

--- a/docs/lanes/j1e6-ci-skills/red-run-evidence.txt
+++ b/docs/lanes/j1e6-ci-skills/red-run-evidence.txt
@@ -1,0 +1,23 @@
+RED PROOF — run 34156222957 (scratch/j1e6-ci-red-proof @ a75782262d056cae722b0fe11ff076d4b2f28d6b)
+https://github.com/microsoft/amplifier-bundle-skills/actions/runs/34156222957
+
+--- job conclusions ---
+success	Lint (ruff)
+success	Bundle structure
+failure	Tests — modules/tool-skills
+failure	Tests — root (Python 3.12)
+failure	Tests — root (Python 3.13)
+failure	Tests — root (Python 3.11)
+
+--- Tests — root (all three Pythons): real suite executing ---
+Tests — root (Python 3.12)	Run root tests	2026-09-07T19:36:44.1959385Z FAILED tests/test_ci_red_proof_DELETEME.py::test_ci_can_go_red_root_suite - AssertionError: deliberate failure: proving the root suite really executes in CI
+Tests — root (Python 3.12)	Run root tests	2026-09-07T19:36:44.1961198Z 1 failed, 27 passed in 0.07s
+Tests — root (Python 3.13)	Run root tests	2026-09-07T19:36:44.5664785Z FAILED tests/test_ci_red_proof_DELETEME.py::test_ci_can_go_red_root_suite - AssertionError: deliberate failure: proving the root suite really executes in CI
+Tests — root (Python 3.13)	Run root tests	2026-09-07T19:36:44.5665468Z 1 failed, 27 passed in 0.05s
+Tests — root (Python 3.11)	Run root tests	2026-09-07T19:36:41.7041078Z FAILED tests/test_ci_red_proof_DELETEME.py::test_ci_can_go_red_root_suite - AssertionError: deliberate failure: proving the root suite really executes in CI
+Tests — root (Python 3.11)	Run root tests	2026-09-07T19:36:41.7041951Z 1 failed, 27 passed in 0.06s
+
+--- Tests — modules/tool-skills ---
+2026-09-07T19:42:51.7367495Z SKIPPED [1] tests/test_real_session.py:28: the `amplifier` CLI is not on PATH -- this is an integration smoke against the installed application, which is not a dependency of this module
+2026-09-07T19:42:51.7369084Z FAILED tests/test_ci_red_proof_DELETEME.py::test_ci_can_go_red_module_suite - AssertionError: deliberate failure: proving the tool-skills suite really executes in CI
+2026-09-07T19:42:51.7370146Z 1 failed, 314 passed, 1 skipped in 1.38s

--- a/docs/lanes/z6wa-skills-visibility-renderer/deliverables_check.py
+++ b/docs/lanes/z6wa-skills-visibility-renderer/deliverables_check.py
@@ -59,9 +59,9 @@ def d2_template_not_hardcoded() -> None:
     v1_block = json.loads(V1.read_text())[11]["new"]
     # No fragment of the captured v1 text may be baked into the renderer.
     v1_lines = [
-        l for l in v1_block.split("\n") if l.startswith("- **") and len(l) > 60
+        line for line in v1_block.split("\n") if line.startswith("- **") and len(line) > 60
     ]
-    leaked = [l for l in v1_lines if l.strip() in src]
+    leaked = [line for line in v1_lines if line.strip() in src]
     # And the block must be assembled from parts, not returned as one literal.
     assembles = 'f"- **{name}**: ' in src or '"- **{name}**: ' in src
     note = NOTE.read_text()

--- a/docs/lanes/z6wa-skills-visibility-renderer/shape_conformance.py
+++ b/docs/lanes/z6wa-skills-visibility-renderer/shape_conformance.py
@@ -154,7 +154,7 @@ def main() -> int:
 
     v1_block = json.loads(V1.read_text())[11]["new"].rstrip("\n")
     v1_names = [
-        m.group(1) for m in (SKILL_LINE.match(l) for l in v1_block.split("\n")) if m
+        m.group(1) for m in (SKILL_LINE.match(line) for line in v1_block.split("\n")) if m
     ]
 
     print("=" * 74)

--- a/modules/tool-skills/tests/test_real_session.py
+++ b/modules/tool-skills/tests/test_real_session.py
@@ -1,13 +1,34 @@
-"""Test that skills are visible in actual amplifier sessions."""
+"""Test that skills are visible in actual amplifier sessions.
+
+This is an INTEGRATION smoke against the installed `amplifier` CLI, not a unit
+test of this module. The CLI is a separate application (microsoft/amplifier-app-cli)
+and is deliberately not a dependency of amplifier-module-tool-skills, so it is
+absent on a clean machine -- including a CI runner. Before the guard below, this
+module shelled out to it unconditionally and died with
+`FileNotFoundError: [Errno 2] No such file or directory: 'amplifier'`; it only
+ever passed because the developer running it happened to have the CLI on PATH.
+
+The skip is reported explicitly (CI runs pytest with `-ra`), so a run where this
+test does not execute says so in the job log rather than looking like coverage.
+"""
 
 import os
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 
+import pytest
+
 
 def test_skills_visible_in_session():
     """Verify skills are visible when running amplifier with the skills bundle."""
+
+    if shutil.which("amplifier") is None:
+        pytest.skip(
+            "the `amplifier` CLI is not on PATH -- this is an integration smoke "
+            "against the installed application, which is not a dependency of this module"
+        )
 
     # Create a test skill
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -59,6 +80,4 @@ This skill should be visible to the agent.""")
 
 
 if __name__ == "__main__":
-    import os
-
     test_skills_visible_in_session()

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,19 @@
+# Ruff configuration for amplifier-bundle-skills.
+#
+# This file exists so `ruff check .` means the SAME thing locally and in CI.
+# Without it, ruff walks up the filesystem looking for a config and can pick up
+# an unrelated parent-directory pyproject.toml -- which is how a local run and a
+# CI run silently disagree about which rules are even enabled. There is no root
+# pyproject.toml here (this repo is a BUNDLE, not a Python package), and
+# modules/tool-skills/pyproject.toml carries no [tool.ruff] block, so without
+# this file NOTHING in the repo has a pinned lint configuration.
+#
+# Settings match the sibling bundle repos microsoft/amplifier-bundle-routing-matrix
+# and microsoft/amplifier-bundle-context-intelligence, so the bundles lint alike.
+#
+# Rule selection is ruff's default (E4, E7, E9, F). CI pins the ruff VERSION
+# (see .github/workflows/ci.yml) because "default rules" is a moving target: a
+# linter that is not version-pinned turns an unrelated upstream release into a
+# red PR nobody changed anything to cause.
+target-version = "py311"
+line-length = 100


### PR DESCRIPTION
## What this adds

This repo had **no `.github/workflows` directory at all**. Every PR merged into it so far
landed with an **empty check list, not a green one** — including #65 and #66, and #66 shipped
`test_visibility_budget.py` and `test_visibility_line_cap.py` that **nothing has ever executed**.

`.github/workflows/ci.yml`, four jobs, all free (no API keys, no LLM, ~2 min):

| Job | What it runs | Scale |
|---|---|---|
| `Lint (ruff)` | `uvx ruff@0.15.7 check .` | whole repo |
| `Tests — root` | `tests/` on Python 3.11 / 3.12 / 3.13 | **27 tests** |
| `Tests — modules/tool-skills` | the module's own suite, `-v` so every test is named in the log | **315 tests** (314 run on a runner, 1 skipped — see below) |
| `Bundle structure` | YAML-parses `bundle.md` frontmatter + `behaviors/*.yaml` + all 38 `skills/*/SKILL.md` | 41 files |

Triggers on `push: main` and `pull_request`. **No path filters, no `continue-on-error`,
no `|| true`** — each of those is a way to be green vacuously.

Also adds `ruff.toml`, because without it *nothing* in this repo pins a lint configuration:
there is no root `pyproject.toml` (this is a bundle, not a Python package) and
`modules/tool-skills/pyproject.toml` carries no `[tool.ruff]` block, so `ruff check .` would
walk up out of the repo looking for one.

## Proof the CI can actually go red

A CI never seen red is decoration. A scratch branch with one deliberately failing assertion
in each suite was pushed, observed red, then **closed and deleted** (PR #67, branch
`scratch/j1e6-ci-red-proof` — gone; verified with `git ls-remote --heads origin 'scratch/*'`,
which returns nothing).

**RED run:** https://github.com/microsoft/amplifier-bundle-skills/actions/runs/34156222957

```
success  Lint (ruff)
success  Bundle structure
failure  Tests — modules/tool-skills
failure  Tests — root (Python 3.11 / 3.12 / 3.13)

Tests — root (3.11)         : 1 failed, 27 passed in 0.06s
Tests — root (3.12)         : 1 failed, 27 passed in 0.07s
Tests — root (3.13)         : 1 failed, 27 passed in 0.05s
Tests — modules/tool-skills : 1 failed, 314 passed, 1 skipped in 1.38s
```

Lint and Bundle structure stayed **green** while the test jobs went red, so the red came from
the **test job running the real suite** — not from a setup or lint error, which would have
proved nothing.

**GREEN run:** https://github.com/microsoft/amplifier-bundle-skills/actions/runs/34156726801 —
all six jobs green, on this PR's HEAD `fbeb717a4b2586912b184bf6f3a3529cb972f7be`:

```
Lint (ruff)                 : All checks passed!
Tests — root (3.11)         : 27 passed in 0.04s
Tests — root (3.12)         : 27 passed in 0.04s
Tests — root (3.13)         : 27 passed in 0.05s
Tests — modules/tool-skills : 314 passed, 1 skipped in 1.52s
Bundle structure            : bundle.md ok | behaviors 2 | skills/*/SKILL.md 38 | OK
```

**GREEN on this PR's final HEAD** (`37d7fdb311a808c35e207dfc61999e3dae6c4e94`, after the lane
note and red-run evidence were added):
https://github.com/microsoft/amplifier-bundle-skills/actions/runs/34157380978 — also all six green.

## The green log now names the visibility guards individually

The workflow above genuinely ran `test_visibility_budget.py` and `test_visibility_line_cap.py`
— but under `pytest -q` a green module job printed only an aggregate (`314 passed, 1 skipped`),
which cannot prove any *particular* test ran. Delete or rename either guard and the number just
gets smaller while the run stays green: the same vacuous-green failure mode the rest of this CI
exists to close, left open in the one place this PR is about.

So the module job now runs `-v` instead of `-q`
(`python -m pytest -v -ra --tb=short`, commit `245b27b`), which prints one
`path::test_name PASSED` line per test. **No test is changed, added, skipped or weakened**;
`-ra`, `--tb=short`, the fixtures guard, the `--frozen --extra remote-sources` sync and every
other job are untouched. The full suite still runs — this changes only what the log reports,
and costs no measurable time (1.61s vs 1.52s for the same suite).

**GREEN readback run:** https://github.com/microsoft/amplifier-bundle-skills/actions/runs/34163453241
— all six jobs green on `245b27ba9c6c39cac0c5b624a24fb85c349a7611`. Pulled from the remote job
log with `gh api .../actions/jobs/101869779846/logs` (job `Tests — modules/tool-skills`),
timestamps stripped, otherwise verbatim:

```
tests/test_visibility_budget.py::test_default_config_is_budget_mode PASSED [ 88%]
tests/test_visibility_line_cap.py::test_description_within_the_cap_is_verbatim PASSED [ 93%]
```

Those are the first line each guard file contributes. That same green log carries **15**
`tests/test_visibility_budget.py::` lines and **13** `tests/test_visibility_line_cap.py::`
lines — every test in both files, each named individually as `PASSED`, with 0 `FAILED`/`ERROR`.

**Confirmed installed, not merely configured.** This PR was squash-merged to `main` as
`dbd5201` while the readback was in flight, so the same evidence now exists on `main` itself:
push run https://github.com/microsoft/amplifier-bundle-skills/actions/runs/34163943164 — all six
jobs green on `dbd5201bd90aa2e88dd0814b40948388ef0c29a4`, job `Tests — modules/tool-skills`
(`101871165945`) carrying the identical **15** + **13** named guard lines and the identical
`314 passed, 1 skipped in 1.61s`.

Full-suite result in the same green job, unchanged:

```
======================== 314 passed, 1 skipped in 1.61s ========================
SKIPPED [1] tests/test_real_session.py:28: the `amplifier` CLI is not on PATH -- ...
```

## Clean main was red — twice. Both fixed as their own commits, not papered over.

**1. `ruff check .` — 3 real E741 findings** (`fix(lint):` commit). Ambiguous variable name `l`
in two archived lane-artifact scripts under `docs/lanes/z6wa-skills-visibility-renderer/`.
Pure loop-variable renames, no behaviour change. Fixed rather than excluded — narrowing the
lint selection or excluding a directory is the same vacuous-green move as `continue-on-error`.

**2. `tests/test_real_session.py` — `FileNotFoundError: 'amplifier'`** (`fix(tests):` commit),
found by the first red-proof run. That test shells out to the `amplifier` CLI, a *separate
application* (`microsoft/amplifier-app-cli`) that is deliberately **not** a dependency of
`amplifier-module-tool-skills`. The dependency was never declared, so the test only ever
passed on a machine where the developer happened to have the CLI installed, and dies on any
clean checkout. The fix makes the dependency explicit — `shutil.which("amplifier")` → skip
with a reason naming why. Installing app-cli from git in CI instead would couple this
module's CI to another repo's `main`, the same "unrelated upstream change turns your PR red"
failure mode the pinned ruff version exists to avoid.

Because a skip is **green**, both test jobs now run pytest with `-ra`, which prints every
non-passing outcome *and its reason* into the job log. Both the red and the green run above
show it working:

```
SKIPPED [1] tests/test_real_session.py:28: the `amplifier` CLI is not on PATH -- this is an
integration smoke against the installed application, which is not a dependency of this module
```

A test that has quietly stopped running can no longer look like coverage.

## Two non-obvious things the module job needs

Both measured on this tree; dropping either silently weakens the job:

1. **`uv sync --frozen --extra remote-sources`.** `amplifier_foundation` lives in an optional
   extra (it is resolved by amplifier's module system, not by the module's core dependencies).
   A plain `uv sync --frozen` + pytest **aborts collection** with
   `ModuleNotFoundError: No module named 'amplifier_foundation'`.
2. **A `test -d tests/fixtures/skills` guard.** Nine tests call
   `pytest.skip("Fixtures directory not found")` when that directory is absent. A future move
   of it would delete nine tests' worth of coverage without ever turning a run red.

## What is deliberately *not* wired

- **No LLM-backed validation.** Skills are prose and the temptation is to have a model judge
  them; that needs API keys and costs money per run.
- **`ruff format --check`.** This repo has never been ruff-formatted — at 0.15.7 defaults
  `ruff format` would rewrite **19 of 56 files**. That whitespace normalisation does not
  belong in the PR that introduces CI (it would collide with every in-flight branch). Named in
  the workflow so the next contributor sees a decision rather than an oversight; the follow-up
  diff is purely mechanical (`uvx ruff@0.15.7 format .`).

## Why ruff is pinned to 0.15.7

"ruff's default rules" is a moving target, so an unpinned linter turns an unrelated upstream
release into a red PR nobody changed anything to cause. 0.15.7 is the version this repo's own
committed lockfile (`modules/tool-skills/uv.lock`) resolves, so CI lints with exactly the ruff
a contributor gets from `uv sync` there.

All three GitHub Actions are pinned to a full commit SHA, each verified to be the SHA its
version tag points at.

