### PR TITLE
feat(tool-skills): add argument completion metadata

### DIFF
--- a/modules/tool-skills/README.md
+++ b/modules/tool-skills/README.md
@@ -470,6 +470,40 @@ allowed-tools: tool-filesystem tool-search tool-bash  # Module IDs — NOT Claud
 | `auto-load` | Skill activates at session start via embedded hooks |
 | `allowed-tools` | Restricts the forked subagent's tool surface. Values are **Amplifier module IDs** (e.g. `tool-filesystem`, `tool-search`, `tool-bash`, `tool-delegate`, `tool-skills`) — NOT Claude Code tool names and NOT callable tool names. A name matching no module yields an **empty** tool set. Omit entirely to inherit the full parent tool surface. |
 
+#### Optional Argument Completion
+
+User-invocable skills may add an `argument-hint` display string, compatible with
+Claude Code command hints. It is display-only; Amplifier never interprets it as
+completion choices.
+
+For literal argument completion, point the standard `metadata` extension mapping
+at an in-skill UTF-8 JSON sidecar:
+
+```yaml
+user-invocable: true
+argument-hint: "[list | review] [action]"
+metadata:
+  amplifier.completions: completions.json
+```
+
+```json
+{
+  "version": 1,
+  "arguments": [
+    {"after": [], "values": ["list", "review"]},
+    {"after": ["review"], "values": ["accept", "decline", "skip"]}
+  ]
+}
+```
+
+Each rule maps the exact completed-argument prefix in `after` to its literal
+`values`; matching is case-sensitive. The sidecar contains no command name or
+aliases—use the existing `shortcut` field for an alias. The sidecar path must
+stay within the skill directory. Its top-level keys must be exactly `version`
+and `arguments`, and each rule must contain exactly `after` and `values`.
+Invalid hints or sidecars are ignored with a warning and do not prevent the
+skill from loading.
+
 ### Creating a Simple Skill
 
 ```bash

--- a/modules/tool-skills/amplifier_module_tool_skills/__init__.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/__init__.py
@@ -6,6 +6,7 @@ Supports local directories and git URL sources for skills.
 
 from __future__ import annotations
 
+import copy
 import logging
 from pathlib import Path
 from collections.abc import Callable, Coroutine
@@ -453,6 +454,39 @@ class SkillsDiscovery:
             if metadata.shortcut and metadata.shortcut != name:
                 shortcuts[metadata.shortcut] = entry
         return shortcuts
+
+    def get_completion_catalog(self) -> list[dict[str, Any]]:
+        """Return cached completion data for user-invocable skills.
+
+        The catalog is derived solely from metadata parsed during discovery. It
+        intentionally does not read skill files or completion sidecars, so it is
+        safe to call while handling interactive completion keystrokes.
+        """
+        shortcuts = self.get_shortcuts()
+        catalog: list[dict[str, Any]] = []
+        for name, metadata in sorted(self._skills.items()):
+            if not metadata.user_invocable:
+                continue
+
+            aliases: list[str] = []
+            if (
+                metadata.shortcut
+                and metadata.shortcut != name
+                and shortcuts.get(metadata.shortcut, {}).get("name") == name
+            ):
+                aliases.append(metadata.shortcut)
+
+            completion_spec = metadata.completion_spec or {}
+            catalog.append(
+                {
+                    "name": name,
+                    "aliases": aliases,
+                    "description": metadata.description,
+                    "argument_hint": metadata.argument_hint,
+                    "arguments": copy.deepcopy(completion_spec.get("arguments", [])),
+                }
+            )
+        return catalog
 
 
 class SkillsTool:

--- a/modules/tool-skills/amplifier_module_tool_skills/discovery.py
+++ b/modules/tool-skills/amplifier_module_tool_skills/discovery.py
@@ -3,11 +3,13 @@ Skill discovery and metadata parsing.
 Shared utilities for finding and parsing SKILL.md files.
 """
 
+import json
 import logging
 import os
 import re
+import unicodedata
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any
 
 import yaml
@@ -22,6 +24,13 @@ VALID_NAME_PATTERN = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 # dispatch table is always keyed in lowercase, mirroring the case-insensitive
 # slash-command lookup the CLI does on user input.
 _SHORTCUT_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")
+
+MAX_ARGUMENT_HINT_LENGTH = 1024
+MAX_COMPLETION_SIDECAR_BYTES = 64 * 1024
+MAX_COMPLETION_RULES = 64
+MAX_COMPLETION_PREFIX_TOKENS = 16
+MAX_COMPLETION_CHOICES = 64
+MAX_COMPLETION_TOKEN_LENGTH = 128
 
 
 def _find_repo_root(path: Path) -> Path | None:
@@ -71,6 +80,133 @@ class SkillMetadata:
     model_role: str | list[str] | None = None  # Model role or fallback chain
     provider_preferences: list[dict] | None = None  # Provider/model preferences
     auto_load: bool = False  # Emit skill:loaded at mount time (for hook-bearing skills)
+    argument_hint: str | None = None  # Display hint for user-invocable command arguments
+    completion_spec: dict[str, Any] | None = None  # Parsed amplifier.completions sidecar
+
+
+def _parse_argument_hint(frontmatter: dict[str, Any], skill_path: Path) -> str | None:
+    """Return a valid display-only argument hint, or disable an invalid one."""
+    argument_hint = frontmatter.get("argument-hint")
+    if argument_hint is None:
+        return None
+    if not isinstance(argument_hint, str) or not argument_hint:
+        logger.warning("Ignoring argument-hint for %s: expected a non-empty string", skill_path)
+        return None
+    if len(argument_hint) > MAX_ARGUMENT_HINT_LENGTH:
+        logger.warning(
+            "Ignoring argument-hint for %s: exceeds %d characters",
+            skill_path,
+            MAX_ARGUMENT_HINT_LENGTH,
+        )
+        return None
+    if not all(character.isprintable() for character in argument_hint):
+        logger.warning(
+            "Ignoring argument-hint for %s: must be a printable single-line string",
+            skill_path,
+        )
+        return None
+    return argument_hint
+
+
+def _read_completion_sidecar(sidecar_path: Path) -> dict[str, Any]:
+    """Read and validate a bounded UTF-8 JSON completion sidecar."""
+    with sidecar_path.open("rb") as sidecar_file:
+        content = sidecar_file.read(MAX_COMPLETION_SIDECAR_BYTES + 1)
+    if len(content) > MAX_COMPLETION_SIDECAR_BYTES:
+        raise ValueError(f"sidecar exceeds {MAX_COMPLETION_SIDECAR_BYTES} bytes")
+
+    try:
+        parsed = json.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("sidecar must be UTF-8 JSON") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError("sidecar must be an object")
+    if set(parsed) != {"version", "arguments"}:
+        raise ValueError("sidecar keys must be exactly version and arguments")
+    if type(parsed.get("version")) is not int or parsed["version"] != 1:
+        raise ValueError("sidecar version must be integer 1")
+
+    arguments = parsed.get("arguments")
+    if not isinstance(arguments, list) or len(arguments) > MAX_COMPLETION_RULES:
+        raise ValueError(f"arguments must contain at most {MAX_COMPLETION_RULES} rules")
+
+    prefixes: set[tuple[str, ...]] = set()
+    validated_rules: list[dict[str, list[str]]] = []
+    for rule in arguments:
+        if not isinstance(rule, dict):
+            raise ValueError("each argument rule must be an object")
+        if set(rule) != {"after", "values"}:
+            raise ValueError("argument rule keys must be exactly after and values")
+        after = rule.get("after")
+        values = rule.get("values")
+        if (
+            not isinstance(after, list)
+            or len(after) > MAX_COMPLETION_PREFIX_TOKENS
+            or not isinstance(values, list)
+            or not values
+            or len(values) > MAX_COMPLETION_CHOICES
+        ):
+            raise ValueError("argument rule has invalid after or values")
+        if any(not _is_completion_literal(token) for token in [*after, *values]):
+            raise ValueError("completion literals must be safe non-empty tokens")
+
+        prefix = tuple(after)
+        if prefix in prefixes or len(values) != len(set(values)):
+            raise ValueError("completion rules and values must not contain duplicates")
+        prefixes.add(prefix)
+        validated_rules.append({"after": list(after), "values": list(values)})
+
+    return {"version": 1, "arguments": validated_rules}
+
+
+def _is_completion_literal(value: Any) -> bool:
+    """Return whether a completion literal is safe to render in a terminal."""
+    return (
+        isinstance(value, str)
+        and bool(value)
+        and len(value) <= MAX_COMPLETION_TOKEN_LENGTH
+        and all(
+            not character.isspace()
+            and not unicodedata.category(character).startswith("C")
+            for character in value
+        )
+    )
+
+
+def _parse_completion_spec(
+    frontmatter: dict[str, Any], skill_path: Path
+) -> dict[str, Any] | None:
+    """Parse the optional Amplifier completion sidecar without blocking discovery."""
+    frontmatter_metadata = frontmatter.get("metadata")
+    if not isinstance(frontmatter_metadata, dict):
+        return None
+
+    sidecar_reference = frontmatter_metadata.get("amplifier.completions")
+    if sidecar_reference is None:
+        return None
+    if not isinstance(sidecar_reference, str) or not sidecar_reference:
+        logger.warning("Ignoring completions for %s: metadata path must be a string", skill_path)
+        return None
+
+    try:
+        relative_path = Path(sidecar_reference)
+        if (
+            relative_path.is_absolute()
+            or PureWindowsPath(sidecar_reference).is_absolute()
+            or ".." in relative_path.parts
+        ):
+            raise ValueError("metadata path must be relative and may not contain '..'")
+
+        skill_dir = skill_path.parent.resolve()
+        sidecar_path = (skill_dir / relative_path).resolve()
+        if not sidecar_path.is_relative_to(skill_dir):
+            raise ValueError("metadata path escapes the skill directory")
+        if not sidecar_path.is_file():
+            raise ValueError("sidecar must be a regular file")
+        return _read_completion_sidecar(sidecar_path)
+    except (OSError, RuntimeError, ValueError) as exc:
+        logger.warning("Ignoring completions for %s: %s", skill_path, exc)
+        return None
 
 
 def parse_skill_frontmatter(skill_path: Path) -> dict[str, Any] | None:
@@ -372,6 +508,9 @@ def discover_skills(skills_dir: Path) -> dict[str, SkillMetadata]:
                             )
                     provider_preferences_val = valid_prefs if valid_prefs else None
 
+            argument_hint = _parse_argument_hint(frontmatter, skill_file)
+            completion_spec = _parse_completion_spec(frontmatter, skill_file)
+
             # Create metadata
             metadata = SkillMetadata(
                 name=name,
@@ -393,6 +532,8 @@ def discover_skills(skills_dir: Path) -> dict[str, SkillMetadata]:
                 model=model_val,
                 model_role=model_role_val,
                 provider_preferences=provider_preferences_val,
+                argument_hint=argument_hint,
+                completion_spec=completion_spec,
             )
 
             skills[name] = metadata

--- a/modules/tool-skills/tests/test_argument_completion.py
+++ b/modules/tool-skills/tests/test_argument_completion.py
@@ -1,0 +1,383 @@
+"""Tests for discovery-time skill argument completion metadata."""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+import amplifier_module_tool_skills.discovery as discovery_module
+from amplifier_module_tool_skills import SkillsDiscovery
+from amplifier_module_tool_skills.discovery import SkillMetadata
+from amplifier_module_tool_skills.discovery import discover_skills
+
+
+def _write_skill(
+    tmp_path: Path,
+    name: str = "review",
+    *,
+    argument_hint: str | None = None,
+    completion_path: str | None = None,
+) -> Path:
+    """Create a user-invocable skill and return its directory."""
+    skill_dir = tmp_path / name
+    skill_dir.mkdir()
+    frontmatter = [
+        "---",
+        f"name: {name}",
+        "description: Review a result",
+        "user-invocable: true",
+    ]
+    if argument_hint is not None:
+        frontmatter.append(f'argument-hint: "{argument_hint}"')
+    if completion_path is not None:
+        frontmatter.extend(
+            ["metadata:", f"  amplifier.completions: {completion_path}"]
+        )
+    frontmatter.extend(["---", "Body"])
+    (skill_dir / "SKILL.md").write_text("\n".join(frontmatter), encoding="utf-8")
+    return skill_dir
+
+
+def _valid_spec() -> dict:
+    return {
+        "version": 1,
+        "arguments": [
+            {"after": [], "values": ["list", "review"]},
+            {"after": ["review"], "values": ["accept", "decline", "skip"]},
+        ],
+    }
+
+
+def _write_spec(skill_dir: Path, spec: object, path: str = "completions.json") -> None:
+    (skill_dir / path).write_text(json.dumps(spec), encoding="utf-8")
+
+
+def test_discovery_parses_valid_hint_and_completion_sidecar(tmp_path: Path):
+    skill_dir = _write_skill(
+        tmp_path, argument_hint="[list | review] [action]", completion_path="completions.json"
+    )
+    spec = _valid_spec()
+    _write_spec(skill_dir, spec)
+
+    metadata = discover_skills(tmp_path)["review"]
+
+    assert metadata.argument_hint == "[list | review] [action]"
+    assert metadata.completion_spec == spec
+
+
+def test_discovery_without_completion_metadata_preserves_existing_behavior(tmp_path: Path):
+    _write_skill(tmp_path)
+
+    metadata = discover_skills(tmp_path)["review"]
+
+    assert metadata.argument_hint is None
+    assert metadata.completion_spec is None
+
+
+@pytest.mark.parametrize(
+    ("spec", "warning"),
+    [
+        ("not json", "object"),
+        ({"version": True, "arguments": []}, "integer 1"),
+        (
+            {
+                "version": 1,
+                "arguments": [{"after": [], "values": ["safe", "safe"]}],
+            },
+            "duplicates",
+        ),
+        (
+            {
+                "version": 1,
+                "arguments": [{"after": [], "values": ["bad value"]}],
+            },
+            "safe non-empty tokens",
+        ),
+        (
+            {
+                "version": 1,
+                "arguments": [{"after": [], "values": ["bad\u001bvalue"]}],
+            },
+            "safe non-empty tokens",
+        ),
+        (
+            {
+                "version": 1,
+                "name": "review",
+                "arguments": [{"after": [], "values": ["list"]}],
+            },
+            "keys must be exactly",
+        ),
+        (
+            {
+                "version": 1,
+                "arguments": [{"after": [], "values": ["list"]}],
+                "typo": True,
+            },
+            "keys must be exactly",
+        ),
+        (
+            {
+                "version": 1,
+                "arguments": [{"after": [], "values": ["list"], "value": "typo"}],
+            },
+            "rule keys must be exactly",
+        ),
+    ],
+)
+def test_invalid_sidecar_warns_and_does_not_drop_skill(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, spec: object, warning: str
+):
+    skill_dir = _write_skill(tmp_path, completion_path="completions.json")
+    _write_spec(skill_dir, spec)
+
+    with caplog.at_level("WARNING"):
+        skills = discover_skills(tmp_path)
+
+    assert "review" in skills
+    assert skills["review"].completion_spec is None
+    assert warning in caplog.text
+
+
+def test_malformed_json_sidecar_warns_and_does_not_drop_skill(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+):
+    skill_dir = _write_skill(tmp_path, completion_path="completions.json")
+    (skill_dir / "completions.json").write_text("{not json", encoding="utf-8")
+
+    with caplog.at_level("WARNING"):
+        skills = discover_skills(tmp_path)
+
+    assert "review" in skills
+    assert skills["review"].completion_spec is None
+    assert "UTF-8 JSON" in caplog.text
+
+
+def test_invalid_hint_warns_without_disabling_valid_sidecar(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+):
+    skill_dir = _write_skill(
+        tmp_path,
+        argument_hint="x" * 1025,
+        completion_path="completions.json",
+    )
+    spec = _valid_spec()
+    _write_spec(skill_dir, spec)
+
+    with caplog.at_level("WARNING"):
+        metadata = discover_skills(tmp_path)["review"]
+
+    assert metadata.argument_hint is None
+    assert metadata.completion_spec == spec
+    assert "argument-hint" in caplog.text
+
+
+@pytest.mark.parametrize("argument_hint", [r"first\nsecond", r"red\x1b[31m"])
+def test_non_printable_argument_hint_warns_without_disabling_valid_sidecar(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, argument_hint: str
+):
+    skill_dir = _write_skill(
+        tmp_path,
+        argument_hint=argument_hint,
+        completion_path="completions.json",
+    )
+    spec = _valid_spec()
+    _write_spec(skill_dir, spec)
+
+    with caplog.at_level("WARNING"):
+        metadata = discover_skills(tmp_path)["review"]
+
+    assert metadata.argument_hint is None
+    assert metadata.completion_spec == spec
+    assert "printable single-line" in caplog.text
+
+
+@pytest.mark.parametrize("completion_path", ["../outside.json", "/outside.json"])
+def test_completion_sidecar_path_escape_is_rejected(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, completion_path: str
+):
+    skill_dir = _write_skill(tmp_path, completion_path=completion_path)
+    _write_spec(tmp_path, _valid_spec(), "outside.json")
+
+    with caplog.at_level("WARNING"):
+        metadata = discover_skills(tmp_path)["review"]
+
+    assert skill_dir.exists()
+    assert metadata.completion_spec is None
+    assert "metadata path must be relative" in caplog.text
+
+
+def test_in_skill_completion_symlink_is_allowed(tmp_path: Path):
+    skill_dir = _write_skill(tmp_path, completion_path="completions.json")
+    targets_dir = skill_dir / "targets"
+    targets_dir.mkdir()
+    _write_spec(targets_dir, _valid_spec())
+    os.symlink(targets_dir / "completions.json", skill_dir / "completions.json")
+
+    assert discover_skills(tmp_path)["review"].completion_spec == _valid_spec()
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFOs are unavailable on this platform")
+def test_fifo_sidecar_is_rejected_without_attempting_to_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    skill_dir = _write_skill(tmp_path, completion_path="completions.json")
+    os.mkfifo(skill_dir / "completions.json")
+
+    def fail_if_read(*args, **kwargs):
+        raise AssertionError("discovery must not read a FIFO sidecar")
+
+    monkeypatch.setattr(discovery_module, "_read_completion_sidecar", fail_if_read)
+
+    metadata = discover_skills(tmp_path)["review"]
+
+    assert metadata.completion_spec is None
+
+
+def test_completion_sidecar_symlink_loop_warns_without_dropping_skill(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+):
+    skill_dir = _write_skill(tmp_path, completion_path="completions.json")
+    os.symlink("completions.json", skill_dir / "completions.json")
+
+    with caplog.at_level("WARNING"):
+        skills = discover_skills(tmp_path)
+
+    assert "review" in skills
+    assert skills["review"].completion_spec is None
+    assert "Ignoring completions" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        {
+            "version": 1,
+            "arguments": [{"after": [], "values": ["choice"]}] * 65,
+        },
+        {
+            "version": 1,
+            "arguments": [{"after": [f"token-{i}" for i in range(17)], "values": ["choice"]}],
+        },
+        {
+            "version": 1,
+            "arguments": [{"after": [], "values": [f"choice-{i}" for i in range(65)]}],
+        },
+        {
+            "version": 1,
+            "arguments": [{"after": [], "values": ["x" * 129]}],
+        },
+    ],
+)
+def test_completion_sidecar_caps_disable_only_completion_metadata(tmp_path: Path, spec: dict):
+    skill_dir = _write_skill(tmp_path, completion_path="completions.json")
+    _write_spec(skill_dir, spec)
+
+    metadata = discover_skills(tmp_path)["review"]
+
+    assert metadata.completion_spec is None
+
+
+def test_completion_sidecar_byte_cap_disables_only_completion_metadata(tmp_path: Path):
+    skill_dir = _write_skill(tmp_path, completion_path="completions.json")
+    (skill_dir / "completions.json").write_bytes(b" " * (64 * 1024 + 1))
+
+    metadata = discover_skills(tmp_path)["review"]
+
+    assert metadata.completion_spec is None
+
+
+def _metadata(
+    name: str,
+    *,
+    shortcut: str | None = None,
+    completion_spec: dict | None = None,
+) -> SkillMetadata:
+    return SkillMetadata(
+        name=name,
+        description=f"{name} description",
+        path=Path(f"/unused/{name}/SKILL.md"),
+        source="/unused",
+        user_invocable=True,
+        shortcut=shortcut,
+        argument_hint="[target]",
+        completion_spec=completion_spec,
+    )
+
+
+def test_completion_catalog_is_fresh_copy_and_performs_no_file_io(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    skill_dir = _write_skill(
+        tmp_path, argument_hint="[target]", completion_path="completions.json"
+    )
+    _write_spec(skill_dir, _valid_spec())
+    discovery = SkillsDiscovery(discover_skills(tmp_path))
+
+    def fail_read_text(*args, **kwargs):
+        raise AssertionError("completion catalog must not read from disk")
+
+    monkeypatch.setattr(Path, "read_text", fail_read_text)
+    catalog = discovery.get_completion_catalog()
+    catalog[0]["arguments"][0]["values"].append("mutated")
+
+    assert discovery.get_completion_catalog() == [
+        {
+            "name": "review",
+            "aliases": [],
+            "description": "Review a result",
+            "argument_hint": "[target]",
+            "arguments": _valid_spec()["arguments"],
+        }
+    ]
+
+
+def test_completion_catalog_uses_the_existing_callable_alias_mapping():
+    rules = _valid_spec()
+    skills = {
+        "review": _metadata("review", shortcut="rvw", completion_spec=rules),
+    }
+    discovery = SkillsDiscovery(skills)
+
+    assert discovery.get_completion_catalog() == [
+        {
+            "name": "review",
+            "aliases": ["rvw"],
+            "description": "review description",
+            "argument_hint": "[target]",
+            "arguments": rules["arguments"],
+        }
+    ]
+    assert discovery.get_shortcuts() == {
+        "review": {
+            "name": "review",
+            "description": "review description",
+            "context": None,
+        },
+        "rvw": {
+            "name": "review",
+            "description": "review description",
+            "context": None,
+        },
+    }
+
+
+def test_completion_catalog_omits_alias_lost_to_existing_shortcut_winner():
+    skills = {
+        "review": _metadata("review", shortcut="go", completion_spec=_valid_spec()),
+        "go": _metadata("go", completion_spec=_valid_spec()),
+    }
+
+    catalog = SkillsDiscovery(skills).get_completion_catalog()
+
+    assert next(record for record in catalog if record["name"] == "review")["aliases"] == []
+
+
+def test_completion_catalog_observes_later_in_place_skill_merges():
+    skills: dict[str, SkillMetadata] = {}
+    discovery = SkillsDiscovery(skills)
+
+    skills["review"] = _metadata("review", completion_spec=_valid_spec())
+
+    assert [record["name"] for record in discovery.get_completion_catalog()] == ["review"]


### PR DESCRIPTION
## Summary
- add optional display-only `argument-hint` metadata for user-invocable skills
- parse bounded, skill-local `metadata.amplifier.completions` JSON sidecars (version 1) with safe literals and warning-only invalid metadata
- expose `SkillsDiscovery.get_completion_catalog()` using canonical names and the existing shortcut catalog without changing legacy shortcut behavior
- document the additive skill format and compatibility boundaries

## Why
Provide an additive, provider-neutral completion catalog for future CLI consumers while keeping skill loading resilient and preventing unbounded, escaping, or terminal-control metadata from entering the catalog. Claude-style hints remain display-only; this change does not claim a standard completion protocol.

## Testing
- `uv run --frozen --extra remote-sources python -m pytest -v -ra --tb=short` — 352 passed
- `uv run --no-project --python 3.11 --with pytest python -m pytest tests -q -ra --tb=short` — 35 passed
- `uvx ruff@0.15.7 check .` — passed
- final diff check and secret-shape scan — passed; no private host, trace, DTU/Gitea payload, or internal model identifier introduced

## Compatibility
- additive: new optional metadata fields and `get_completion_catalog()` only
- existing `get_shortcuts()` behavior and shortcut alias rules are unchanged
- invalid optional hints/sidecars warn and are ignored; they do not prevent skill loading
- no app-cli consumer is included; downstream consumers can adopt the catalog independently

## Breaking changes
None.